### PR TITLE
Add EnvFollow and Poll UGens

### DIFF
--- a/sc.asd
+++ b/sc.asd
@@ -45,6 +45,8 @@
 	       (:file "ugens/freeverb")
 	       (:file "ugens/math")
 	       (:file "ugens/grains")
+	       (:file "ugens/poll")
+	       (:file "ugens/extras/envfollow")
 	       (:file "ugens/extras/mdapiano")
 	       (:file "ugens/extras/joshpv")
 	       (:file "ugens/extras/pitchdetection")))

--- a/server.lisp
+++ b/server.lisp
@@ -259,7 +259,9 @@
 	 (funcall handle))
        (alexandria:removef (node-watcher rt-server) id)))
     (add-reply-responder
-     "/d_removed" (lambda (&rest args) (declare (ignore args))))))
+     "/d_removed" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/tr" (lambda (id label value) (format t "Poll (~a ~a): ~a~%" id label value)))))
 
 
 

--- a/ugens/extras/envfollow.lisp
+++ b/ugens/extras/envfollow.lisp
@@ -1,3 +1,6 @@
+
+(in-package #:sc)
+
 (defugen (env-follow "EnvFollow")
     (&optional (in 0.0) (decaycoeff 0.99) (mul 1.0) (add 0.0))
   ((:ar (madd (multinew new 'pure-ugen in decaycoeff) mul add))

--- a/ugens/extras/envfollow.lisp
+++ b/ugens/extras/envfollow.lisp
@@ -1,0 +1,4 @@
+(defugen (env-follow "EnvFollow")
+    (&optional (in 0.0) (decaycoeff 0.99) (mul 1.0) (add 0.0))
+  ((:ar (madd (multinew new 'pure-ugen in decaycoeff) mul add))
+   (:kr (madd (multinew new 'pure-ugen in decaycoeff) mul add))))

--- a/ugens/poll.lisp
+++ b/ugens/poll.lisp
@@ -1,0 +1,7 @@
+
+(in-package #:sc)
+
+(defugen (poll "Poll")
+    (&optional (trig 0) (in 0.0) (label 0) (trigid -1))
+  ((:ar (multinew new 'pure-ugen trig in label trigid))
+   (:kr (multinew new 'pure-ugen trig in label trigid))))


### PR DESCRIPTION
These changes add the Poll and EnvFollow UGens. EnvFollow is part of sc3-plugins, not the main supercollider distribution, so some users may not have it.

I also added an OSC responder so that Poll's output would be printed in the REPL. However it seems like in some cases Poll will be removed by the compiler if it's not part of the audio output.