### PR TITLE
sbcl: server STDOUT to *standard-output* when run-program output = t

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -57,7 +57,7 @@
 
 (defun run-program (command &key output wait)
   #+ccl (ccl:run-program "/bin/sh" (list "-c" command) :output output :wait wait)
-  #+sbcl (sb-ext:run-program "/bin/sh" (list "-c" command) :output output :wait wait)
+  #+sbcl (sb-ext:run-program "/bin/sh" (list "-c" command) :output (if (eql output t) *standard-output* output) :wait wait)
   #+clisp (ext:run-program "/bin/sh" :arguments (list "-c" command) :output (if (eql output t) :terminal output) :wait wait)
   #+abcl (progn
 	   wait


### PR DESCRIPTION
It looks like SBCL isn't printing stdout from the server when #'sc::run-program :output is t. This is a simple fix to make SBCL post scsynth's output in the REPL.