### PR TITLE
only convert atoms at the head of lists.

### DIFF
--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -220,11 +220,13 @@
     (ash 'sc::ash~)
     (t atom)))
 
-(defun convert-code (form)
+(defun convert-code (form &optional head)
   (cond ((null form) nil)
-	((atom form) (convert-code-table form))
-	(t (cons (convert-code (car form))
-		 (convert-code (cdr form))))))
+	((atom form) (if head
+		(convert-code-table form)
+		form))
+	(t (cons (convert-code (car form) t)
+		 (mapcar #'convert-code (cdr form))))))
 
 
 (defmacro synth-funcall-definition (name args)


### PR DESCRIPTION
This change prevents variables that have the same name as functions from being converted to the name of the function.

Previous behavior:
```lisp
> (sc::convert-code '(exp exp))
(SC::EXP~ SC::EXP~)
```

New/corrected behavior:
```lisp
> (sc::convert-code '(exp exp))
(SC::EXP~ EXP)
```