### PR TITLE
detect-silence may have side effects so it should not be pure-ugen.

### DIFF
--- a/ugens/filter.lisp
+++ b/ugens/filter.lisp
@@ -234,8 +234,8 @@
 
 (defugen (detect-silence "DetectSilence")
     (&optional (in 0.0) (amp 0.0001) &key (time 0.1) (act :no-action))
-  ((:ar (multinew new 'pure-ugen in amp time (act act)))
-   (:kr (multinew new 'pure-ugen in amp time (act act))))
+  ((:ar (multinew new 'ugen in amp time (act act)))
+   (:kr (multinew new 'ugen in amp time (act act))))
   :check-fn #'check-same-rate-as-first-input)
 
 


### PR DESCRIPTION
Since detect-silence has possible side effects (i.e. freeing the synth) it should not be a pure-ugen. This commit fixes that.