### PR TITLE
Add bus allocation & handling; few other minor fixes

### DIFF
--- a/bus.lisp
+++ b/bus.lisp
@@ -1,0 +1,59 @@
+
+(in-package #:sc)
+
+(defclass bus ()
+  ((busnum :initarg :busnum :initform nil :accessor busnum)
+   (type :initarg :type :initform :audio)
+   (chanls :initarg :chanls :initform nil :accessor chanls)
+   (server :initarg :server :initform nil :accessor server)))
+
+(defmethod print-object ((self bus) stream)
+  (format stream "#<~a-BUS :server ~a :busnum ~a :channels ~a>"
+          (symbol-name (slot-value self 'type)) (server self) (busnum self) (chanls self)))
+
+(defmethod floatfy ((bus bus))
+  (floatfy (busnum bus)))
+
+(defun get-next-bus (server &optional (type :audio) (channels 1) busnum)
+  (assert (member type '(:audio :control)) (type))
+  (labels ((find-consecutive-nil (&optional (type :audio) (channels 1) (start 0))
+             (let* ((buses (if (eq type :audio)
+                               (audio-buses server)
+                               (control-buses server)))
+                    (pos (position nil buses :start start)))
+               (if (loop :for i :upto (1- channels)
+                      :do (when (not (null (elt buses (+ pos i))))
+                            (return t)))
+                   (find-consecutive-nil type channels (1+ pos))
+                   pos))))
+    (bt:with-lock-held ((server-lock server))
+      (let* ((busnum (or busnum (find-consecutive-nil type channels)))
+             (bus-obj (make-instance 'bus :type type :busnum busnum :server server :chanls channels)))
+        (loop :for i :upto (1- channels)
+           :do (setf (elt (if (eq type :audio)
+                              (audio-buses server)
+                              (control-buses server))
+                          (+ busnum i))
+                     bus-obj))
+        bus-obj))))
+
+(defun bus-alloc (type &key (chanls 1) busnum (server *s*))
+  (assert (member type '(:audio :control)) (type))
+  (get-next-bus server type chanls busnum))
+
+(defun bus-audio (&key (chanls 1) busnum (server *s*))
+  (bus-alloc :audio :chanls chanls :busnum busnum :server server))
+
+(defun bus-control (&key (chanls 1) busnum (server *s*))
+  (bus-alloc :control :chanls chanls :busnum busnum :server server))
+
+(defun bus-free (bus &key (server *s*))
+  (let ((type (slot-value bus 'type)))
+    (bt:with-lock-held ((server-lock server))
+      (loop :for i :upto (1- (chanls bus))
+         :do
+         (setf (elt (if (eq type :audio)
+                        (audio-buses server)
+                        (control-buses server))
+                    (+ i (busnum bus)))
+               nil)))))

--- a/package.lisp
+++ b/package.lisp
@@ -86,6 +86,11 @@
 	   #:clear-buf
 	   #:local-buf-list
 
+       #:bus-audio
+       #:bus-control
+       #:bus-free
+       #:busnum
+
 	   #:neg
 	   #:reciprocal
 	   #:frac

--- a/package.lisp
+++ b/package.lisp
@@ -56,6 +56,7 @@
 	   #:at
 	   #:bye
 	   #:free
+       #:release
 	   #:ctrl
 	   #:is-playing-p
 

--- a/sc.asd
+++ b/sc.asd
@@ -17,6 +17,7 @@
 	       (:file "server-options")
 	       (:file "server")
 	       (:file "buffer")
+	       (:file "bus")
 	       (:file "ugen")
 	       (:file "synthdef")
 	       (:file "operators")

--- a/server.lisp
+++ b/server.lisp
@@ -47,7 +47,10 @@
   (:documentation "All data that is sent to the server must be in Float32 format. This function converts lisp objects to Float32."))
 
 (defmethod floatfy ((object t))
-  object)
+  (cond
+    ((null object) 0.0)
+    ((eq t object) 1.0)
+    (t object)))
 
 (defmethod floatfy ((number number))
   (float number))

--- a/server.lisp
+++ b/server.lisp
@@ -487,6 +487,10 @@
   (with-node (node id server)
     (message-distribute node (list 11 id) server))) ;; /n_free == 11
 
+(defun release (node)
+  "Set the gate argument of NODE to 0, releasing the node."
+  (ctrl node :gate 0))
+
 (defun is-playing-p (node)
   (with-node (node id server)
     (when (find id (node-watcher server))

--- a/ugen.lisp
+++ b/ugen.lisp
@@ -88,9 +88,14 @@
   :scalar)
 
 (defmethod rate ((ugen list))
-  (let ((rate-lst (mapcar #'(lambda (u) (string (rate u))) (alexandria:flatten ugen))))
-    (let ((ret (intern (first (sort rate-lst #'string-lessp)) :keyword)))
-      ret)))
+  (if (null ugen)
+      :scalar
+      (let ((rate-lst (mapcar #'(lambda (u) (string (rate u))) (alexandria:flatten ugen))))
+        (let ((ret (intern (first (sort rate-lst #'string-lessp)) :keyword)))
+          ret))))
+
+(defmethod rate ((ugen t))
+  (if (eq ugen t) :scalar))
 
 
 (defun act (act)
@@ -156,6 +161,10 @@
   (dolist (input (inputs ugen))
     (unless (typep input 'ugen)
       (add-constant (synthdef ugen) (floatfy input)))))
+
+(defmethod collect-constants ((ugen t))
+  (add-constant (synthdef ugen) (cond ((null ugen) 0.0)
+                                      ((eq t ugen) 1.0))))
 
 (defmethod optimize-graph ((ugen ugen)))
 


### PR DESCRIPTION
This PR adds bus allocation similar to the buffer allocation already implemented. Manually specifying the bus number is no longer needed.

Use the `bus-audio` function to make a new audio bus, and `bus-control` to make a new control bus. Use `bus-free` to free a bus.

Additionally I made a few other minor changes:

- Added a `release` function to set the `gate` of a node to 0.
- Updated `floatfy` function to convert `nil` to 0 and `t` to 1.
- Fixed the `rate` function to return the highest rate from a list.