### PR TITLE
3 minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is an experimental project, so changes to the API are possible.
 (play (sin-osc.ar [320 321] 0 .2))
 
 ;; Stop music
-(bye *)
+(free *)
 
 ;; Quit SuperCollider server
 (server-quit *s*)

--- a/server.lisp
+++ b/server.lisp
@@ -485,9 +485,9 @@
 						       param))) server)))
 
 (defun bye (node)
-  "It was deprecated. It will remove!"
-  (with-node (node id server)
-    (message-distribute node (list 11 id) server))) ;; /n_free == 11
+  "Deprecated function; use `free' instead."
+  (warn "#'bye is deprecated; please use #'free instead.")
+  (free node))
 
 (defun free (node)
   (with-node (node id server)

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -225,6 +225,13 @@
 	((atom form) (if head
 		(convert-code-table form)
 		form))
+     ((position (car form) (list 'let 'let*)) ;; avoid converting names of local bindings
+      `(,(car form) ,(mapcar (lambda (item)
+                               (if (atom item)
+                                   item
+                                   `(,(car item) ,@(convert-code (cdr item)))))
+                             (cadr form))
+        ,@(convert-code (cddr form))))
 	(t (cons (convert-code (car form) t)
 		 (mapcar #'convert-code (cdr form))))))
 

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -310,7 +310,7 @@
        (labels ((clear-node ()
 		  (when (and ,node  (is-playing-p ,node))
 		    (if (getf (meta ,node) :is-signal-p) (ctrl ,node :gate 0 :fade ,fade)
-			(bye ,node)))))
+			(free ,node)))))
 	 ,(if body `(progn
 		      (let ((*temp-synth-name* ,(string-downcase key)))
 			(prog1 (setf (gethash ,key (node-proxy-table *s*))

--- a/ugens/compander.lisp
+++ b/ugens/compander.lisp
@@ -15,8 +15,8 @@
   ((:ar (madd (multinew new 'ugen in control thresh slope-below slope-above clamp-time
 			relax-time) mul add))))
 
-(defun compander-d.ar (&optional (in 0.0) &key (thresh 0.5) (slope-below 1.0) (slope-above 1.0)
-					    (clamp-time 0.01) (relax-time 0.01) (mul 1.0) (add 0.0))
+(defun compander-d.ar (&optional (in 0.0) (thresh 0.5) (slope-below 1.0) (slope-above 1.0)
+					    (clamp-time 0.01) (relax-time 0.01) &key (mul 1.0) (add 0.0))
   (madd (compander.ar (delay-n.ar in clamp-time clamp-time) in
 		      thresh slope-below slope-above clamp-time relax-time) mul add))
 


### PR DESCRIPTION
This PR includes 3 minor improvements:

- Remove a few references to `bye` and replace them with `free`. Also forward `bye` to `free` to avoid code duplication, and give a warning when `bye` is used.
- Fix arguments of `compander-d` to match the arguments of `compander`
- Fix `convert-code` to avoid converting the names of local bindings in `let` or `let*`:

Example, before:

```lisp
(sc::convert-code '(let ((mod (mod (lf-saw.ar 3 0 3) 1)))
  mod))
;=> (LET ((SC::MOD~ (SC::MOD~ (LF-SAW.AR 3 0 3) 1)))
;  SC::MOD~)
```

Example, after:

```lisp
(sc::convert-code '(let ((mod (mod (lf-saw.ar 3 0 3) 1)))
  mod))
;=> (LET ((MOD (SC::MOD~ (LF-SAW.AR 3 0 3) 1)))
;  MOD)
```