### PR TITLE
synth function, RLPFD ugen, synthdef metadata

### DIFF
--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -310,6 +310,21 @@
 	 (sync)
 	 ,node))))
 
+(defun synth (name &optional args)
+  "Start a synth by name."
+  (let* ((name-string (string-downcase (symbol-name name)))
+         (next-id (get-next-id *s*))
+         (to 1)
+         (pos :head)
+         (new-synth (make-instance 'node :server *s* :id next-id :name name-string :pos pos :to to))
+         (parameter-names (get-synthdef-control-names name))
+         (args (loop :for (arg val) :on args :by #'cddr
+                  :for pos = (position arg parameter-names :test #'string-equal)
+                  :unless (null pos)
+                  :append (list (string-downcase (nth pos parameter-names)) val))))
+    (message-distribute new-synth
+                        (apply #'make-synth-msg *s* name-string next-id to pos args)
+                        *s*)))
 
 (defmacro proxy (key &optional body &key (gain 1.0) (fade 0.5) (pos :head) (to 1) (out-bus 0))
   (alexandria:with-gensyms (node)

--- a/ugens/filter.lisp
+++ b/ugens/filter.lisp
@@ -346,3 +346,11 @@
    (:kr
     (madd (multinew new 'pure-ugen in freq gain reset) mul add)))
   :check-fn #'check-same-rate-as-first-input)
+
+(defugen (rlpfd "RLPFD")
+    (in &optional (ffreq 440) (res 0) (dist 0) (mul 1) (add 0))
+  ((:ar
+    (madd (multinew new 'pure-ugen in ffreq res dist) mul add))
+   (:kr
+    (madd (multinew new 'pure-ugen in ffreq res dist) mul add)))
+  :check-fn #'check-same-rate-as-first-input)

--- a/util.lisp
+++ b/util.lisp
@@ -68,5 +68,9 @@
 	  output wait
 	  (ext:system (format nil "/bin/sh -c \"~a\"" command))))
 
-
+(defun as-keyword (object)
+  (alexandria:make-keyword
+   (etypecase object
+     (symbol object)
+     (string (string-upcase object)))))
 


### PR DESCRIPTION
3 changes:

- the `synth` function to start a synth by name.
- the `RLPFD` UGen which emulates a tb-303 ladder filter
- keep track of synthdef metadata when `defsynth` or `proxy` are used. synthdef metadata currently includes the name of the synthdef, any arguments/parameters for it, and the body.