### PR TITLE
several changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is an experimental project, so changes to the API are possible.
 - [Scheduler](http://github.com/byulparan/scheduler)(above 2017.3.14) - The time based task scheduler
 
 ## Usage:
-- package: `sc`, `sc-user(use this package)`
+- package: `sc`, `sc-user` (use this package)
 - named-readtable: `sc`
 
 ```cl

--- a/buffer.lisp
+++ b/buffer.lisp
@@ -138,6 +138,10 @@
 (defun buffer-zero (buffer)
   (send-message (server buffer) "/b_zero" (bufnum buffer) 0))
 
+(defmethod buffer-dur ((buffer buffer))
+  "Get the duration in seconds of BUFFER."
+  (/ (frames buffer) (sr buffer)))
+
 ;;; wavetable
 (defun wavetable (buffer wave data &optional (normalize t) (as-wavetable t) (clear-first t))
   (apply #'send-message

--- a/buffer.lisp
+++ b/buffer.lisp
@@ -9,8 +9,8 @@
    (server :initarg :server :initform nil :accessor server)))
 
 (defmethod print-object ((self buffer) stream)
-  (format stream "#<BUFFER :server ~a :bufnum ~a :frames ~a :channels ~a :samplerate ~a :path ~s>"
-	  (server self) (bufnum self) (frames self) (chanls self) (sr self) (path self)))
+  (format stream "#<~s :server ~s :bufnum ~s :frames ~s :channels ~s :samplerate ~s :path ~s>"
+          'buffer (server self) (bufnum self) (frames self) (chanls self) (sr self) (path self)))
 
 (defmethod initialize-instance :after ((self buffer) &key)
   (setf (elt (buffers (server self)) (bufnum self)) self))

--- a/bus.lisp
+++ b/bus.lisp
@@ -57,3 +57,12 @@
                         (control-buses server))
                     (+ i (busnum bus)))
                nil)))))
+
+(defun bus-string (bus)
+  "Make a string representing the bus that the server can understand."
+  (with-slots (type busnum) bus
+    (format nil "~a~a"
+            (if (eq :audio type)
+                "a"
+                "c")
+            busnum)))

--- a/bus.lisp
+++ b/bus.lisp
@@ -8,8 +8,8 @@
    (server :initarg :server :initform nil :accessor server)))
 
 (defmethod print-object ((self bus) stream)
-  (format stream "#<~a-BUS :server ~a :busnum ~a :channels ~a>"
-          (symbol-name (slot-value self 'type)) (server self) (busnum self) (chanls self)))
+  (format stream "#<~s :type ~s :server ~s :busnum ~s :channels ~s>"
+          'bus (slot-value self 'type) (server self) (busnum self) (chanls self)))
 
 (defmethod floatfy ((bus bus))
   (floatfy (busnum bus)))

--- a/package.lisp
+++ b/package.lisp
@@ -94,6 +94,7 @@
        #:bus-audio
        #:bus-control
        #:bus-free
+       #:bus-string
        #:busnum
 
 	   #:neg

--- a/package.lisp
+++ b/package.lisp
@@ -60,6 +60,7 @@
 	   #:free
        #:release
 	   #:ctrl
+       #:map-bus
 	   #:is-playing-p
 
 	   #:make-group

--- a/package.lisp
+++ b/package.lisp
@@ -83,6 +83,7 @@
 	   #:buffer-set
 	   #:buffer-set-list
 	   #:buffer-zero
+       #:buffer-dur
 	   #:wavetable
 	   #:calc-pv-recsize
 	   #:local-buf

--- a/package.lisp
+++ b/package.lisp
@@ -23,6 +23,7 @@
 	   #:*synth-definition-mode*
 	   #:defsynth
 	   #:synth
+       #:get-synthdef-metadata
 	   #:with-controls
 	   #:play
 	   #:proxy

--- a/server.lisp
+++ b/server.lisp
@@ -316,8 +316,8 @@
     :reader just-connect-p)))
 
 (defmethod print-object ((self external-server) stream)
-  (format stream "#<SC-SYNTH ~a-~d:~d>"
-	  (name self) (host self) (port self)))
+  (format stream "#<~s ~a-~d:~d>"
+          'external-server (name self) (host self) (port self)))
 
 (defun all-running-servers ()
   (remove-if-not #'(lambda (server) (boot-p server)) *all-rt-servers*))
@@ -452,7 +452,7 @@
    (meta :initarg :meta :initform nil :reader meta)))
 
 (defmethod print-object ((node node) stream)
-  (format stream "#<Node :server ~s :id ~a :name ~s>" (server node) (id node) (name node)))
+  (format stream "#<~s :server ~s :id ~s :name ~s>" 'node (server node) (id node) (name node)))
 
 (defmacro at (time &body body)
   `(let ((*run-level* :bundle)
@@ -514,7 +514,7 @@
   ())
 
 (defmethod print-object ((node group) stream)
-  (format stream "#<Group :server ~s :id ~a>" (server node) (id node)))
+  (format stream "#<~s :server ~s :id ~s>" 'group (server node) (id node)))
 
 (let ((new-group-id 1))
   (defun make-group (&key id (server *s*) (pos :after) (to 1))

--- a/server.lisp
+++ b/server.lisp
@@ -490,6 +490,13 @@
     (message-distribute node (cons 15 (cons id (mapcar #'(lambda (p) (cond ((symbolp p) (string-downcase p)) ;key
 								       (t (floatfy p)))) ;value
 						       param))) server)))
+(defun map-bus (node &rest param &key &allow-other-keys)
+  "Map a bus or buses onto the specified controls of a node."
+  (with-node (node id server)
+    (message-distribute node (append (list "/n_map" id) (mapcar (lambda (p) (cond ((symbolp p) (string-downcase p))
+                                                                                  (t (floatfy p))))
+                                                                param))
+                        server)))
 
 (defun bye (node)
   "Deprecated function; use `free' instead."

--- a/server.lisp
+++ b/server.lisp
@@ -497,11 +497,12 @@
   (free node))
 
 (defun free (node)
+  "Free a node running on the server."
   (with-node (node id server)
-    (message-distribute node (list 11 id) server))) ;; /n_free == 11
+    (message-distribute node (list "/n_free" id) server)))
 
 (defun release (node)
-  "Set the gate argument of NODE to 0, releasing the node."
+  "Set the gate control of NODE to 0, releasing the node."
   (ctrl node :gate 0))
 
 (defun is-playing-p (node)

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -14,7 +14,7 @@
    (rewrite-in-progress :initform nil :accessor rewrite-in-progress)))
 
 (defmethod print-object ((c synthdef) stream)
-  (format stream "#<SynthDef:~a>" (name c)))
+  (format stream "#<~s :name ~s>" 'synthdef (name c)))
 
 (defmethod add-ugen ((synthdef synthdef) (ugen ugen))
   (unless (rewrite-in-progress synthdef)

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -311,11 +311,11 @@
 (defun synth (name &rest args)
   "Start a synth by name."
   (let* ((name-string (string-downcase (symbol-name name)))
-         (next-id (get-next-id *s*))
-         (to 1)
-         (pos :head)
+         (next-id (or (getf args :id) (get-next-id *s*)))
+         (to (or (getf args :to) 1))
+         (pos (or (getf args :pos) :head))
          (new-synth (make-instance 'node :server *s* :id next-id :name name-string :pos pos :to to))
-         (parameter-names (mapcar (lambda (param) (string-downcase (car param))) (getf (sc::get-synthdef-metadata name) :controls)))
+         (parameter-names (mapcar (lambda (param) (string-downcase (car param))) (getf (get-synthdef-metadata name) :controls)))
          (args (loop :for (arg val) :on args :by #'cddr
 		  :for pos = (position (string-downcase arg) parameter-names :test #'string-equal)
 		  :unless (null pos)

--- a/ugen.lisp
+++ b/ugen.lisp
@@ -137,7 +137,10 @@
   ())
 
 (defmethod print-object ((c ugen) stream)
-  (format stream "#<~a:~a>" (name c) (string-downcase (rate c))))
+  (format stream "#<~s ~a.~a>" 'ugen (name c) (case (rate c)
+                                                (:audio "ar")
+                                                (:control "kr")
+                                                (:scalar "ar"))))
 
 (defmethod new1 ((ugen ugen) &rest inputs)
   (setf (inputs ugen) inputs)
@@ -275,7 +278,7 @@
    (output-index :initarg :output-index :reader output-index)))
 
 (defmethod print-object ((c proxy-output) stream)
-  (format stream "#<UGen.ProxyOutput ~a>" (output-index c)))
+  (format stream "#<~s :output-index ~s>" 'proxy-output (output-index c)))
 
 (defclass multiout-ugen (ugen)
   ((channels :accessor channels)))


### PR DESCRIPTION
This PR has a few relatively minor changes:

- add and export `buffer-dur` convenience method to get the duration of a buffer in seconds.
- add and export `bus-string` convenience method to get a string that scsynth can use to map a node's parameter to a bus.
- alllow `:to`, `:pos`, and `:id` to be specified as arguments to `synth` as per #34.
- export `get-synthdef-metadata`
- minor changes to `print-object` for several classes to print objects in a more standard way, i.e. using the class symbol so it's always printed with the correct package name or none if current package.
- a few minor docstring/documentation additions/fixes
- add and export `map-bus` function to map a bus to the argument of a node.

I'm also planning on improving `ctrl` in the future so that it will automatically map buses to node arguments when necessary.