### PR TITLE
add testugens (including CheckBadValues and Sanitize UGens)

### DIFF
--- a/sc.asd
+++ b/sc.asd
@@ -47,6 +47,7 @@
 	       (:file "ugens/math")
 	       (:file "ugens/grains")
 	       (:file "ugens/poll")
+	       (:file "ugens/testugens")
 	       (:file "ugens/extras/envfollow")
 	       (:file "ugens/extras/mdapiano")
 	       (:file "ugens/extras/joshpv")

--- a/ugens/testugens.lisp
+++ b/ugens/testugens.lisp
@@ -1,0 +1,11 @@
+(in-package #:sc)
+
+(defugen (check-bad-values "CheckBadValues")
+    (&optional (in 0.0) (id 0) (post 2))
+  ((:ar (multinew new 'ugen in id post))
+   (:kr (multinew new 'ugen in id post))))
+
+(defugen (sanitize "Sanitize")
+    (&optional (in 0.0) (replace 0.0))
+  ((:ar (multinew new 'ugen in replace))
+   (:kr (multinew new 'ugen in replace))))


### PR DESCRIPTION
This PR adds the `CheckBadValues` and `Sanitize` UGens. Sanitize was added to SuperCollider in 3.9.0.