### PR TITLE
add ladspa ugen + few other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It is an experimental project, so changes to the API are possible.
 If you have your own additional libraries, please report me. I will add here.
 
 - [sc-extensions](https://github.com/byulparan/sc-extensions) - extension library
+- [cl-patterns](https://github.com/defaultxr/cl-patterns) - patterns/sequencing library
 
 ## Usage:
 - package: `sc`, `sc-user` (use this package)

--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -56,4 +56,5 @@
 	       (:file "ugens/extras/envfollow")
 	       (:file "ugens/extras/mdapiano")
 	       (:file "ugens/extras/joshpv")
-	       (:file "ugens/extras/pitchdetection")))
+	       (:file "ugens/extras/pitchdetection")
+	       (:file "ugens/extras/ladspa")))

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -232,6 +232,9 @@
                                    `(,(car item) ,@(convert-code (cdr item)))))
                              (cadr form))
         ,@(convert-code (cddr form))))
+     ((position (car form) (list 'destructuring-bind))
+      `(,(car form) ,(cadr form) ,(caddr form)
+         ,@(convert-code (cdddr form))))
 	(t (cons (convert-code (car form) t)
 		 (mapcar #'convert-code (cdr form))))))
 

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -245,7 +245,7 @@
 
 (defun get-synthdef-metadata (synth &optional key)
   "Get metadata about the synthdef with the name of SYNTH. When KEY is provided, return that specific item from the metadata (i.e. controls, body, etc)."
-  (let ((metadata (gethash (as-keyword synth) *synthdef-metadata*)))
+  (let ((metadata (gethash (as-keyword (if (typep synth 'node) (name synth) synth)) *synthdef-metadata*)))
     (if key
         (getf metadata (as-keyword key))
         metadata)))

--- a/ugens/extras/ladspa.lisp
+++ b/ugens/extras/ladspa.lisp
@@ -1,0 +1,5 @@
+(in-package #:cl-collider)
+
+(defugen (ladspa "LADSPA")
+    (num-channels id &rest args)
+  ((:ar (multinew-list new 'multiout-ugen (append (list 1 num-channels id) args)))))


### PR DESCRIPTION
Here are the changes in this PR:

- add ladspa UGen (from sc3-plugins)
- fix `destructuring-bind` handling in `convert-code`
- fix `get-synthdef-metadata` so it returns information correctly when its argument is a node
- add cl-patterns contrib link. cl-patterns is my sequencing/patterns library that supports using cl-collider as its audio backend.