### PR TITLE
Add Gendy UGens.

### DIFF
--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -52,6 +52,7 @@
 	       (:file "ugens/math")
 	       (:file "ugens/grains")
 	       (:file "ugens/poll")
+	       (:file "ugens/stochastic")
 	       (:file "ugens/testugens")
 	       (:file "ugens/extras/envfollow")
 	       (:file "ugens/extras/mdapiano")

--- a/ugens/stochastic.lisp
+++ b/ugens/stochastic.lisp
@@ -1,0 +1,57 @@
+
+(in-package #:sc)
+
+(defugen (gendy1 "Gendy1")
+    (&optional (amp-dist 1) (dur-dist 1) (ad-param 1.0) (dd-param 1.0)
+	       (min-freq 440.0) (max-freq 660.0) (amp-scale 0.5) (dur-scale 0.5)
+	       (init-cps 12) knum (mul 1.0) (add 1.0))
+  ((:ar (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum)
+	      mul add))
+   (:kr (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum)
+	      mul add))))
+
+(defugen (gendy2 "Gendy2")
+    (&optional (amp-dist 1) (dur-dist 1) (ad-param 1.0) (dd-param 1.0)
+	       (min-freq 440.0) (max-freq 660.0) (amp-scale 0.5) (dur-scale 0.5)
+	       (init-cps 12) knum (a 1.17) (c 0.31) (mul 1.0) (add 1.0))
+  ((:ar (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum a c)
+	      mul add))
+   (:kr (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum a c)
+	      mul add))))
+
+(defugen (gendy3 "Gendy3")
+    (&optional (amp-dist 1) (dur-dist 1) (ad-param 1.0) (dd-param 1.0)
+	       (freq 440.0) (amp-scale 0.5) (dur-scale 0.5)
+	       (init-cps 12) knum (mul 1.0) (add 1.0))
+  ((:ar (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param freq
+			amp-scale dur-scale init-cps knum)
+	      mul add))
+   (:kr (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param freq
+			amp-scale dur-scale init-cps knum)
+	      mul add))))
+
+(defugen (gendy4 "Gendy4")
+    (&optional (amp-dist 1) (dur-dist 1) (ad-param 1.0) (dd-param 1.0)
+	       (min-freq 440.0) (max-freq 660.0) (amp-scale 0.5) (dur-scale 0.5)
+	       (init-cps 12) knum (mul 1.0) (add 1.0))
+  ((:ar (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum)
+	      mul add))
+   (:kr (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum)
+	      mul add))))
+
+(defugen (gendy5 "Gendy5")
+    (&optional (amp-dist 1) (dur-dist 1) (ad-param 1.0) (dd-param 1.0)
+	       (min-freq 440.0) (max-freq 660.0) (amp-scale 0.5) (dur-scale 0.5)
+	       (init-cps 12) knum (mul 1.0) (add 1.0))
+  ((:ar (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum)
+	      mul add))
+   (:kr (madd (multinew new 'ugen amp-dist dur-dist ad-param dd-param min-freq
+			max-freq amp-scale dur-scale init-cps knum)
+	      mul add))))


### PR DESCRIPTION
This pull request adds defugens for dynamic stochastic synthesis generators UGens. `gendy1` through `gendy3` are on the default class library. `gendy4` and `gendy5` are extensions, but they are included here nonetheless.