### PR TITLE
Improve default paths in Windows

### DIFF
--- a/server.lisp
+++ b/server.lisp
@@ -3,11 +3,19 @@
 (defvar *s* nil
   "Special symbol bound to the default scsynth server. If functions do not specify a target server, that message is sent to the *s* server.")
 
+#+windows
+(defvar *win-sc-dir*
+  (or (find-if (alexandria:compose (alexandria:curry #'search "SuperCollider")
+				   #'namestring)
+	       (uiop:subdirectories (uiop:getenv-pathname "ProgramFiles"))
+	       :from-end t)
+      (progn (warn "SuperCollider was not found in the default path.") #p"")))
+
 ;; default path are which build target from source
 (defvar *sc-synth-program*
   #+darwin "/Applications/SuperCollider/SuperCollider.app/Contents/Resources/scsynth"
   #+linux "/usr/local/bin/scsynth"
-  #+windows "c:/Program Files/SuperCollider-3.9.3/scsynth.exe"
+  #+windows (merge-pathnames *win-sc-dir* #P"scsynth.exe")
   "The path to the scsynth binary.")
 
 (setf *sc-plugin-paths*
@@ -15,7 +23,7 @@
 		 "~/Library/Application\ Support/SuperCollider/Extensions/")
   #+linux (list "/usr/local/lib/SuperCollider/plugins/"
 		"/usr/local/share/SuperCollider/Extensions/")
-  #+windows (list "c:/Program Files/SuperCollider-3.9.3/plugins/"
+  #+windows (list (merge-pathnames #P"plugins/" *win-sc-dir*)
 		  (full-pathname (merge-pathnames #P"SuperCollider/Extensions/"
 						  (uiop:get-folder-path :local-appdata)))))
 


### PR DESCRIPTION
By default, SuperCollider installs in a directory whose name contains the version number, e.g. "C:\Program Files\SuperCollider-3.10.0\". If the variables for the default paths in cl-collider point to a directory with the latest version number, users with other versions have to manually set them. Also when new versions of SuperCollider come out and are installed, changes have to be made.
To avoid this, this PR adds an automatic search for the SuperCollider directory in %ProgramFiles%.