### PR TITLE
use simple-inferiors to run supercollider server

### DIFF
--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -12,7 +12,8 @@
 	       #:pileup
 	       #:flexi-streams
 	       #:split-sequence
-	       #:named-readtables)
+	       #:named-readtables
+           #:simple-inferiors)
   :serial t
   :components ((:file "package")
 	       #+(or sbcl ecl) (:file "id-map")

--- a/server-options.lisp
+++ b/server-options.lisp
@@ -25,29 +25,32 @@
 	)
 
 (defun build-server-options (server-options)
-  (append
-   (list "-c" (write-to-string (server-options-num-control-bus server-options))
-				 "-a" (write-to-string (server-options-num-audio-bus server-options))
-				 "-i" (write-to-string (server-options-num-input-bus server-options))
-				 "-o" (write-to-string (server-options-num-output-bus server-options))
-				 "-z" (write-to-string (server-options-block-size server-options))
-				 ;;-Z hardware-buffer-size
-				 "-S" (write-to-string (server-options-hardware-samplerate server-options))
-				 "-b" (write-to-string (server-options-num-sample-buffers server-options))
-				 "-n" (write-to-string (server-options-max-num-nodes server-options))
-				 "-d" (write-to-string (server-options-max-num-synthdefs server-options))
-				 "-m" (write-to-string (server-options-realtime-mem-size server-options))
-				 "-w" (write-to-string (server-options-num-wire-buffers server-options))
-				 "-r" (write-to-string (server-options-num-random-seeds server-options))
-				 "-D" (write-to-string (server-options-load-synthdefs-p server-options))
-				 "-R" (write-to-string (server-options-publish-to-rendezvous-p server-options))
-				 "-l" (write-to-string (server-options-max-logins server-options))
-				 "-V" (write-to-string (server-options-verbosity server-options))
-				 "-H" (write-to-string (server-options-device server-options))
-				 )
-	 (let* ((paths (server-options-ugen-plugins-path server-options)))
-		 (if (not paths) nil
-				 (list "-U" (format nil
-														#-windows "\"~{~a~^:~}\""
-														#+windows "\"~{~a~^;~}\""
-														paths))))))
+  (mapcar (lambda (opt)
+            (if (stringp opt)
+                opt
+                (write-to-string opt)))
+          (append
+           (list "-c" (server-options-num-control-bus server-options)
+		         "-a" (server-options-num-audio-bus server-options)
+		         "-i" (server-options-num-input-bus server-options)
+		         "-o" (server-options-num-output-bus server-options)
+		         "-z" (server-options-block-size server-options)
+		         ;;-Z hardware-buffer-size
+		         "-S" (server-options-hardware-samplerate server-options)
+		         "-b" (server-options-num-sample-buffers server-options)
+		         "-n" (server-options-max-num-nodes server-options)
+		         "-d" (server-options-max-num-synthdefs server-options)
+		         "-m" (server-options-realtime-mem-size server-options)
+		         "-w" (server-options-num-wire-buffers server-options)
+		         "-r" (server-options-num-random-seeds server-options)
+		         "-D" (server-options-load-synthdefs-p server-options)
+		         "-R" (server-options-publish-to-rendezvous-p server-options)
+		         "-l" (server-options-max-logins server-options)
+		         "-V" (server-options-verbosity server-options)
+		         "-H" (server-options-device server-options)
+		         )
+           (let* ((paths (server-options-ugen-plugins-path server-options)))
+	         (if (not paths) nil
+		         (list "-U" (format nil
+							        "~{~a~^:~}"
+							        paths)))))))

--- a/util.lisp
+++ b/util.lisp
@@ -48,21 +48,9 @@
   (apply #'append sequence sequences))
 
 
-#-windows
 (defun sc-program-run (program options)
-  (let* ((command 
-	   (format nil "\"~a\" ~{~a ~}"
-		   program options)))
-    (uiop:run-program command
-		      :output :interactive)))
-
-#+windows
-(defun sc-program-run (program options)
-  (let* ((command 
-	   (format nil "\"\"~a\" ~{~a ~}\""
-		   program options)))
-    (uiop:run-program command
-		      :output :interactive)))
+  (simple-inferiors:run program options
+  		                :output t :copier :line))
 
 
 #+windows


### PR DESCRIPTION
Hi,

When using cl-collider via SLIME in Emacs, I'm not getting any of scsynth's console output (i.e. Poll output, response to `sc:server-query-all-nodes`, etc) in my SLIME repl. When I asked in #lisp on Freenode about this, it was recommended to use [simple-inferiors](https://github.com/Shinmera/simple-inferiors) instead of `uiop:run-program` directly. After making that change, I was able to get scsynth's console output in my SLIME repl again as expected.

Since simple-inferiors automatically quotes the name of the program and its arguments, I also updated `server-options.lisp` in order to avoid double-quoting them, and only convert non-strings to strings.

I also removed some of the Windows-specific code as I expect simple-inferiors should work the same on both platforms. However, I haven't tested this on Windows, so maybe someone should check to make sure everything still works as expected before this is merged.