### PR TITLE
fix i-env-gen + other minor changes

### DIFF
--- a/buffer.lisp
+++ b/buffer.lisp
@@ -229,6 +229,7 @@
   "Read a soundfile located at PATH as a wavetable."
   (let* ((tmp-buf (prog1 (buffer-read path)
                     (sync)))
+         (full-path (slot-value tmp-buf 'path))
          (file-frames (slot-value tmp-buf 'frames))
          (powers-of-two (mapcar (lambda (x) (expt 2 (1+ x))) (alexandria:iota 16)))
          (num-frames (nth (position-if (lambda (x) (>= x file-frames)) powers-of-two) powers-of-two))
@@ -237,4 +238,5 @@
                    (buffer-free tmp-buf)))
          (buffer (buffer-alloc (* 2 num-frames))))
     (buffer-setn buffer (list-in-wavetable-format (linear-resample frames num-frames)))
+    (setf (slot-value buffer 'path) full-path)
     buffer))

--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -60,5 +60,6 @@
 	       (:file "ugens/extras/envfollow")
 	       (:file "ugens/extras/mdapiano")
 	       (:file "ugens/extras/joshpv")
+	       (:file "ugens/extras/mcldbufferugens")
 	       (:file "ugens/extras/pitchdetection")
 	       (:file "ugens/extras/ladspa")))

--- a/operators.lisp
+++ b/operators.lisp
@@ -468,13 +468,11 @@
   (list list))
 
 (defun flop (lists)
-  (labels ((this-nth (n list)
-	     (nth (mod n (length list)) list)))
-    (let* ((lists (mapcar #'alexandria:ensure-list lists))
-	   (len (apply #'max (mapcar #'length lists))))
-      (loop repeat len
-	    for i from 0
-	    collect (mapcar (lambda (list) (this-nth i list)) lists)))))
+  (let* ((lists (mapcar #'alexandria:ensure-list lists))
+	     (len (apply #'max (mapcar #'length lists))))
+    (loop repeat len
+	   for i from 0
+	   collect (mapcar (lambda (list) (nth-wrap i list)) lists))))
 
 (defun clump (lists n)
   (loop for i from 0 below (length lists) by n

--- a/server.lisp
+++ b/server.lisp
@@ -444,7 +444,7 @@
     `(let* ((,file-name (full-pathname ,output-files))
 	    (,osc-file (cat (subseq ,file-name 0 (position #\. ,file-name)) ".osc"))
 	    (*s* (make-instance 'nrt-server :name "NRTSynth" :streams nil)))
-       (make-group 1 :pos :head :to 0)
+       (make-group :id 1 :pos :head :to 0)
        ,@body
        (when ,pad (send-bundle *s* (* 1.0d0 ,pad) (list "/c_set" 0 0)))
        (with-open-file (,non-realtime-stream ,osc-file :direction :output :if-exists :supersede
@@ -455,14 +455,14 @@
 	     (write-sequence (osc::encode-int32 (length ,message)) ,non-realtime-stream)
 	     (write-sequence ,message ,non-realtime-stream))))
        (sc-program-run (full-pathname *sc-synth-program*)
-		       (list "-U" (format nil "~{\"~a\"~^:~}" (mapcar #'full-pathname *sc-plugin-paths*))
-			     "-N" ,osc-file
-			     "_" ,file-name ,sr (string-upcase (pathname-type ,file-name))
-			     (ecase ,format
-			       (:int16 "int16")
-			       (:int24 "int24")
-			       (:float "float")
-			       (:double "double"))))
+		               (list "-U" (format nil "~{~a~^:~}" (mapcar #'full-pathname *sc-plugin-paths*))
+			                 "-N" ,osc-file
+			                 "_" ,file-name ,(write-to-string sr) (string-upcase (pathname-type ,file-name))
+			                 (ecase ,format
+			                   (:int16 "int16")
+			                   (:int24 "int24")
+			                   (:float "float")
+			                   (:double "double"))))
        (unless ,keep-osc-file
 	 (delete-file ,osc-file))
        (values))))
@@ -560,7 +560,6 @@
       (let* ((group-id (if id id (incf new-group-id)))
 	     (group (make-instance 'group :server server :id group-id :pos pos :to target-id)))
 	(message-distribute group (list "/g_new" group-id (node-to-pos pos) target-id) server)
-	(sync)
 	group))))
 
 (defun server-query-all-nodes (&optional (rt-server *s*))

--- a/ugens/extras/mcldbufferugens.lisp
+++ b/ugens/extras/mcldbufferugens.lisp
@@ -1,0 +1,21 @@
+(in-package #:sc)
+
+;; Logger
+
+;; ListTrig
+
+;; ListTrig2
+
+;; GaussClass
+
+;; BufMax
+
+;; BufMin
+
+(defugen (array-max "ArrayMax") (array)
+  ((:ar (multinew-list new 'multiout-ugen (append (list 2) array)))
+   (:kr (multinew-list new 'multiout-ugen (append (list 2) array)))))
+
+(defugen (array-min "ArrayMin") (array)
+  ((:ar (multinew-list new 'multiout-ugen (append (list 2) array)))
+   (:kr (multinew-list new 'multiout-ugen (append (list 2) array)))))

--- a/ugens/ienvgen.lisp
+++ b/ugens/ienvgen.lisp
@@ -1,8 +1,26 @@
 (in-package #:sc)
 
+(defun as-array-for-interpolation (env)
+  "Convert ENV into an array in a format suitable for i-env-gen."
+  (with-slots (levels times curve-value) env
+    (let* ((size (length times))
+           (contents (append (list
+                              0 ;; Env offset (not implemented in cl-collider)
+                              (elt levels 0)
+                              size
+                              (reduce #'+ times))
+                             (loop :for i :from 0 :below size
+                                :append (list (elt times i)
+                                              (env-shape-number (nth-wrap i curve-value))
+                                              (nth-wrap i curve-value)
+                                              (elt levels (1+ i)))))))
+      (mapcar (lambda (list)
+                (coerce list 'vector))
+              (flop contents)))))
+
 (defugen (i-env-gen "IEnvGen")
     (envelope index &optional (mul 1.0) (add 0.0))
   ((:ar (madd (unbubble (mapcar #'process-env (multinew new 'ugen index
-						  (make-env-array-from-env envelope)))) mul add))
+						                                (as-array-for-interpolation envelope)))) mul add))
    (:kr (madd (unbubble (mapcar #'process-env (multinew new 'ugen index
-						  (make-env-array-from-env envelope)))) mul add))))
+						                                (as-array-for-interpolation envelope)))) mul add))))


### PR DESCRIPTION
This PR fixes `i-env-gen`. `IEnvGen` uses a different format than `EnvGen` does, so a new function had to be written for it.

Additionally, loading a file as a wavetable now preserves the path of the file loaded in the buffer metadata.

I also modified `flop` to use `nth-wrap` instead of rewriting it in a `labels`.