### PR TITLE
enhance *sc-synth-program* and *sc-plugin-path* detection on linux

### DIFF
--- a/server-options.lisp
+++ b/server-options.lisp
@@ -21,8 +21,8 @@
   (max-logins 1)
   (verbosity 0)
   (ugen-plugins-path (mapcar #'full-pathname *sc-plugin-paths*))
-	(device "cl-collider")
-	)
+  (device nil))
+  
 
 (defun build-server-options (server-options)
   (reduce #'append

--- a/server-options.lisp
+++ b/server-options.lisp
@@ -25,33 +25,36 @@
 	)
 
 (defun build-server-options (server-options)
-  (mapcar (lambda (opt)
-            (if (stringp opt)
-                opt
-                (write-to-string opt)))
-          (append
-           (list "-c" (server-options-num-control-bus server-options)
-		         "-a" (server-options-num-audio-bus server-options)
-		         "-i" (server-options-num-input-bus server-options)
-		         "-o" (server-options-num-output-bus server-options)
-		         "-z" (server-options-block-size server-options)
-		         ;;-Z hardware-buffer-size
-		         "-S" (server-options-hardware-samplerate server-options)
-		         "-b" (server-options-num-sample-buffers server-options)
-		         "-n" (server-options-max-num-nodes server-options)
-		         "-d" (server-options-max-num-synthdefs server-options)
-		         "-m" (server-options-realtime-mem-size server-options)
-		         "-w" (server-options-num-wire-buffers server-options)
-		         "-r" (server-options-num-random-seeds server-options)
-		         "-D" (server-options-load-synthdefs-p server-options)
-		         "-R" (server-options-publish-to-rendezvous-p server-options)
-		         "-l" (server-options-max-logins server-options)
-		         "-V" (server-options-verbosity server-options)
-		         "-H" (server-options-device server-options)
-		         )
-           (let* ((paths (server-options-ugen-plugins-path server-options)))
-	         (if (not paths) nil
-		         (list "-U" (format nil
-							        #-windows "~{~a~^:~}"
-                                    #+windows "~{~a~^;~}"
-							        paths)))))))
+  (reduce #'append
+    (mapcar (lambda (pair)
+              (let ((param-name (first pair))
+                    (param-value (funcall (second pair) server-options)))
+                (when param-value
+                  (list param-name
+                        (if (stringp param-value)
+                          param-value
+                          (write-to-string param-value))))))
+            (list '("-c" server-options-num-control-bus)
+                  '("-a" server-options-num-audio-bus)
+                  '("-i" server-options-num-input-bus)
+                  '("-o" server-options-num-output-bus)
+                  '("-z" server-options-block-size)
+                  '("-S" server-options-hardware-samplerate)
+                  '("-b" server-options-num-sample-buffers)
+                  '("-n" server-options-max-num-nodes)
+                  '("-d" server-options-max-num-synthdefs)
+                  '("-m" server-options-realtime-mem-size)
+                  '("-w" server-options-num-wire-buffers)
+                  '("-r" server-options-num-random-seeds)
+                  '("-D" server-options-load-synthdefs-p)
+                  '("-R" server-options-publish-to-rendezvous-p)
+                  '("-l" server-options-max-logins)
+                  '("-V" server-options-verbosity)
+                  '("-H" server-options-device)))
+             
+    :initial-value (let* ((paths (server-options-ugen-plugins-path server-options)))
+                       (if (not paths) nil
+                        (list "-U" (format nil
+                                    #-windows "~{~a~^:~}"
+                                                 #+windows "~{~a~^;~}"
+                                    paths))))))

--- a/server.lisp
+++ b/server.lisp
@@ -14,7 +14,11 @@
 ;; default path are which build target from source
 (defvar *sc-synth-program*
   #+darwin "/Applications/SuperCollider/SuperCollider.app/Contents/Resources/scsynth"
-  #+linux "/usr/local/bin/scsynth"
+  #+linux (handler-case
+            (uiop:run-program "which scsynth" :output :line)
+            (t (c)
+               (warn "SuperCollider was not found in the system path.")
+               nil))
   #+windows (merge-pathnames *win-sc-dir* #P"scsynth.exe")
   "The path to the scsynth binary.")
 

--- a/server.lisp
+++ b/server.lisp
@@ -25,8 +25,13 @@
 (setf *sc-plugin-paths*
   #+darwin (list "/Applications/SuperCollider/SuperCollider.app/Contents/Resources/plugins/"
 		 "~/Library/Application\ Support/SuperCollider/Extensions/")
-  #+linux (list "/usr/local/lib/SuperCollider/plugins/"
-		"/usr/local/share/SuperCollider/Extensions/")
+  #+linux (remove-if-not
+            #'uiop:directory-exists-p
+            (list
+              "/usr/local/lib/SuperCollider/plugins/"
+              "/usr/lib/SuperCollider/plugins/"
+              "/usr/local/share/SuperCollider/Extensions/"
+              "/usr/share/SuperCollider/Extensions/"))
   #+windows (list (merge-pathnames #P"plugins/" *win-sc-dir*)
 		  (full-pathname (merge-pathnames #P"SuperCollider/Extensions/"
 						  (uiop:get-folder-path :local-appdata)))))


### PR DESCRIPTION
The scsynth binary is searched in system path, so this should work in all distros and all ways of installation.

For the plugin dirs there is larger set of possible locations that now covers default Makefile and default of debian based distros. Locations of other distros can be easily added in the future. Only locations that actually exist are used.