### PR TITLE
Fix `running-sum-rms` and export it

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -168,7 +168,8 @@
 	   #:ifft
 	   #:pvcalc
 	   #:pvcalc2
-	   #:pv-collect))
+	   #:pv-collect
+	   #:running-sum-rms))
 
 (defpackage #:sc-user
   (:use #:cl #:sc))

--- a/ugens/fft.lisp
+++ b/ugens/fft.lisp
@@ -201,6 +201,6 @@
    (:kr (multinew new 'ugen in num-samp))))
 
 (defun running-sum-rms (in &optional (num-samp 40.0))
-  (sqrt
+  (sqrt~
    (mul (running-sum.ar (squared in) num-samp)
 	(reciprocal num-samp))))


### PR DESCRIPTION
Call `sqrt~` instead of `sqrt` and export `running-sum-rms`.