### PR TITLE
Optimize wavetable conversion

### DIFF
--- a/buffer.lisp
+++ b/buffer.lisp
@@ -152,15 +152,17 @@
 	result))))
 
 (defun buffer-get-to-list (buffer &optional (start 0) (frames (slot-value buffer 'frames)))
-  "Get a list of the frames of BUFFER. Unlike `buffer-get-list', this function is not limited by OSC packet size and can return any number of frames, though it may be slower. This is synchronous function, do not call in reply thread."
+  "Get a list of the frames of BUFFER. Unlike `buffer-get-list', this function is not limited by OSC packet size and can return any number of frames, though it may be slower.
+
+Note that this is a synchronous function, so you should not call it in the reply thread."
   (let ((end (+ start frames)))
     (assert (>= (frames buffer) end) nil "Buffer index ~a out of range (buffer size: ~a)" (+ start frames) (frames buffer))
     (loop :while (< start end)
-	  :append
-	  (let ((dec (min 400 (- end start))))
-            (prog1
-		(buffer-getn buffer start dec)
-              (incf start dec))))))
+       :append
+         (let ((dec (min 400 (- end start))))
+           (prog1
+               (buffer-getn buffer start dec)
+             (incf start dec))))))
 
 (defun buffer-load-to-list (buffer &optional (start 0) (frames (slot-value buffer 'frames)))
   "Write BUFFER to a temporary file, then load the values back into a list and return it. The values are from index START and for the number of FRAMES, if provided, or otherwise until the end of the buffer. ACTION is a function which will be passed the resulting list as an argument and evaluated once the file has been read. This is synchronous function, do not call in reply thread."
@@ -237,6 +239,6 @@
                      (buffer-get-to-list tmp-buf)
                    (buffer-free tmp-buf)))
          (buffer (buffer-alloc (* 2 num-frames))))
-    (buffer-setn buffer (list-in-wavetable-format (linear-resample frames num-frames)))
+    (buffer-setn buffer (list-in-wavetable-format (coerce (linear-resample frames num-frames) 'vector)))
     (setf (slot-value buffer 'path) full-path)
     buffer))

--- a/util.lisp
+++ b/util.lisp
@@ -80,17 +80,17 @@
 
 (defun nth-wrap (n list)
   "Get the Nth value of LIST, wrapping around if the value is bigger or smaller than the list length."
-  (nth (mod n (length list)) list))
+  (elt list (mod n (length list))))
 
 (defun blend-nth (n list)
   "Get the Nth value of LIST, linearly interpolating between the adjacent values if N is not an integer."
   (if (= n (round n))
-      (nth n list)
+      (elt list n)
       (let* ((floor (floor n))
              (ceiling (ceiling n))
              (fl-diff (- n floor)))
-        (+ (* (nth floor list) (- 1 fl-diff))
-           (* (nth ceiling list) fl-diff)))))
+        (+ (* (elt list floor) (- 1 fl-diff))
+           (* (elt list ceiling) fl-diff)))))
 
 (defun linear-resample (list new-size)
   "Using linear interpolation, resample the values of LIST to a new list of size NEW-SIZE."


### PR DESCRIPTION
This change uses `elt` instead of `nth` in `nth-wrap` and `blend-nth` in order to allow them to be used for any type of sequence.

It also coerces the resampled list to a vector when loading a sound as a wavetable. This greatly increases the speed of the `list-in-wavetable-format` function.