### PR TITLE
make `free` a generic function

### DIFF
--- a/buffer.lisp
+++ b/buffer.lisp
@@ -104,8 +104,11 @@
       (send-message server "/b_free" buffer))
     free-buffer))
 
-(defmethod buffer-free ((buffer buffer) &key (server *s*) complete-handler)
-  (buffer-free (bufnum buffer) :server server :complete-handler complete-handler))
+(defmethod buffer-free ((buffer buffer) &key server complete-handler)
+  (buffer-free (bufnum buffer) :server (or server (slot-value buffer 'server)) :complete-handler complete-handler))
+
+(defmethod free ((buffer buffer))
+  (buffer-free buffer))
 
 (defun buffer-normalize (buffer &key (server *s*) (new-max 1.0) wavetable-p complete-handler)
   (with-sync-or-call-handle (server buffer "/b_gen" complete-handler)

--- a/server.lisp
+++ b/server.lisp
@@ -95,6 +95,9 @@
   (:documentation "The scsynth server can run across the network.
  If the server is running on the local machine, return T, otherwise NIL."))
 
+(defgeneric free (object)
+  (:documentation "Free a node or buffer on the server."))
+
 (defgeneric sr (buffer))
 (defgeneric (setf sr) (sr buffer))
 (defgeneric chanls (buffer))
@@ -552,8 +555,7 @@
   (warn "#'bye is deprecated; please use #'free instead.")
   (free node))
 
-(defun free (node)
-  "Free a node running on the server."
+(defmethod free ((node node))
   (with-node (node id server)
     (message-distribute node (list "/n_free" id) server)))
 


### PR DESCRIPTION
This just makes `free` into a generic function, so it can be used on buffers, nodes, and possibly other objects in the future.