### PR TITLE
Export symbols and cleanup package

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -46,6 +46,7 @@
 	   #:make-external-server
 	   #:server-boot
 	   #:server-quit
+	   #:boot-p
 	   #:send-message
 	   #:send-bundle
 	   #:addr
@@ -92,6 +93,7 @@
 	   #:sr
 	   #:frames
 	   #:chanls
+	   #:path
 	   #:buffer-read
 	   #:buffer-read-channel
 	   #:buffer-alloc

--- a/package.lisp
+++ b/package.lisp
@@ -42,15 +42,12 @@
 	   #:with-rendering
 
 	   #:all-running-servers
-	   #:reply-log-p
 	   #:make-external-server
 	   #:server-boot
 	   #:server-quit
-	   #:boot-p
+	   #:boot-p 
 	   #:send-message
 	   #:send-bundle
-	   #:addr
-	   #:lisp-port
 
 	   #:control-get
 	   #:control-set
@@ -169,7 +166,6 @@
 	   #:env-as-signal
 
 	   #:fft
-	   #:ifft
 	   #:pvcalc
 	   #:pvcalc2
 	   #:pv-collect


### PR DESCRIPTION
This PR exports (buffer) `path` and (server) `boot-p`. Also removes unused symbols from the exported list in the package definition.