### PR TITLE
conditionally load swank extensions

### DIFF
--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -13,11 +13,12 @@
 	       #:flexi-streams
 	       #:split-sequence
 	       #:named-readtables
-           #:simple-inferiors)
+	       #:simple-inferiors)
   :serial t
   :components ((:file "package")
 	       #+(or sbcl ecl) (:file "id-map")
 	       (:file "util")
+	       ;; swank-extensions.lisp conditionally loaded at the end of util.lisp
 	       (:file "server-options")
 	       (:file "scheduler")
 	       (:file "server")

--- a/swank-extensions.lisp
+++ b/swank-extensions.lisp
@@ -1,0 +1,20 @@
+(in-package #:cl-collider)
+
+;; make slime show the synthdef's argument list for (synth ...)
+(defmethod swank::compute-enriched-decoded-arglist ((operator-form (eql 'synth)) argument-forms)
+  (let* ((fst (car argument-forms))
+         (controls (unless (typep fst 'swank::arglist-dummy)
+                     (synthdef-metadata (if (and (listp fst)
+                                                 (eql 'quote (car fst)))
+                                            (cadr fst)
+                                            fst)
+                                        :controls))))
+    (if controls
+        (let ((req (loop :for ctl :in controls
+                      :if (atom ctl)
+                      :collect ctl))
+              (key (loop :for ctl :in controls
+                      :if (listp ctl)
+                      :collect (swank::make-keyword-arg (alexandria:make-keyword (car ctl)) (car ctl) (cadr ctl)))))
+          (swank::make-arglist :required-args (append (list fst) req) :key-p t :keyword-args key))
+        (call-next-method))))

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -338,27 +338,6 @@
                         (apply #'make-synth-msg *s* name-string next-id to pos args)
                         *s*)))
 
-#+swank ;; make slime show the synthdef's argument list for (synth ...)
-(defmethod swank::compute-enriched-decoded-arglist ((operator-form (eql 'synth)) argument-forms)
-  (let* ((fst (car argument-forms))
-         (controls (unless (typep fst 'swank::arglist-dummy)
-                     (synthdef-metadata (if (and (listp fst)
-                                                 (eql 'quote (car fst)))
-                                            (cadr fst)
-                                            fst)
-                                        :controls))))
-    (if controls
-        (let ((req (loop :for ctl :in controls
-                      :if (atom ctl)
-                      :collect ctl))
-              (key (loop :for ctl :in controls
-                      :if (listp ctl)
-                      :collect (swank::make-keyword-arg (alexandria:make-keyword (car ctl)) (car ctl) (cadr ctl)))))
-          (swank::make-arglist :required-args (append (list fst) req) :key-p t :keyword-args key))
-        (call-next-method))))
-
-
-
 (defun get-controls-list (form)
   "Scan FORM for (with-controls ...) and return the list of controls if it exists, or NIL otherwise."
   (cond ((null form) nil)

--- a/util.lisp
+++ b/util.lisp
@@ -101,3 +101,9 @@
         list
         (loop :for i :from 0 :below new-size
            :collect (blend-nth (* i factor) list)))))
+
+;; conditionally load swank extensions
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (when (alexandria:featurep :swank)
+    (load (asdf:system-relative-pathname :cl-collider "swank-extensions.lisp"))))
+


### PR DESCRIPTION
The library fails to load without Swank if had previously been compiled with it. My use of `#+swank` for this functionality was incorrect. Loading the functionality from a separate file via an `eval-when` instead fixes this issue.

This issue was originally reported for my own library at https://github.com/defaultxr/cl-patterns/issues/7 .