### PR TITLE
Add buffer fill methods, change `wavetable` to `buffer-fill`

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -109,7 +109,7 @@
 	   #:buffer-dur
 	   #:buffer-copy
 	   
-	   #:wavetable
+	   #:buffer-fill
 	   #:buffer-read-as-wavetable
 	   #:calc-pv-recsize
 	   #:local-buf


### PR DESCRIPTION
Scsynth has three routines to fill a buffer with sine waves: sine1 (only amplitudes for each partial), sine2 (also specifying frequency partials) and sine3 (also specifying frequency partials and phases). The function `wavetable` currently only accesses the first one. This PR adds the other two, abstracting away the particular method used to communicate to the server.

The name of the function is also changed to `buffer-fill`. This mechanism can be used beyond wavetable synthesis, and the data can in fact be created in wavetable format or not. I think `buffer-fill` is more descriptive, but I'd be glad to amend if you feel otherwise.