### PR TITLE
Add docstrings for UGens

### DIFF
--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -12,7 +12,8 @@
 	       #:flexi-streams
 	       #:split-sequence
 	       #:named-readtables
-	       #-lispworks #:simple-inferiors)
+	       #-lispworks #:simple-inferiors
+	       #:cl-ppcre)
   :serial t
   :components ((:file "package")
 	       #-ccl (:file "id-map")

--- a/server.lisp
+++ b/server.lisp
@@ -49,6 +49,13 @@
 					    (uiop:get-folder-path :local-appdata)))
   "The directory where the scsyndef files for synthdefs are saved.")
 
+(defvar *sc-help-paths*
+  (mapcar (lambda (dir)
+	    (merge-pathnames (make-pathname :directory '(:relative :back "HelpSource" "Classes"))
+			     dir))
+	  *sc-plugin-paths*)
+  "A list of directories where helpfiles for SuperCollider UGens will be searched.")
+
 ;;; -------------------------------------------------------
 ;;; Server - base class
 ;;; -------------------------------------------------------


### PR DESCRIPTION
This sets the docstrings of the functions corresponding to the various UGens, according to their description on the helpfiles installed together with SuperCollider (if one such file exists).

The helpfiles come written in [SCDoc Syntax](http://doc.sccode.org/Reference/SCDocSyntax.html). Most features are ignored, other than finding the appropriate section and removing markup tags.

I only tested the code to find the correct documentation directory in Windows. It should also work in MacOS and Linux... testing on these systems would be appreciated!