### PR TITLE
provide the swank extensions for slynk as well

### DIFF
--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -18,7 +18,7 @@
   :components ((:file "package")
 	       #-ccl (:file "id-map")
 	       (:file "util")
-	       ;; swank-extensions.lisp conditionally loaded at the end of util.lisp
+	       ;; swank-extensions.lisp/slynk-extensions.lisp conditionally loaded at the end of util.lisp
 	       (:file "server-options")
 	       (:file "scheduler")
 	       (:file "server")

--- a/slynk-extensions.lisp
+++ b/slynk-extensions.lisp
@@ -1,0 +1,20 @@
+(in-package #:cl-collider)
+
+;; make sly show the synthdef's argument list for (synth ...)
+(defmethod slynk::compute-enriched-decoded-arglist ((operator-form (eql 'synth)) argument-forms)
+  (let* ((fst (car argument-forms))
+         (controls (unless (typep fst 'slynk::arglist-dummy)
+                     (synthdef-metadata (if (and (listp fst)
+                                                 (eql 'quote (car fst)))
+                                            (cadr fst)
+                                            fst)
+                                        :controls))))
+    (if controls
+        (let ((req (loop :for ctl :in controls
+                      :if (atom ctl)
+                      :collect ctl))
+              (key (loop :for ctl :in controls
+                      :if (listp ctl)
+                      :collect (slynk::make-keyword-arg (alexandria:make-keyword (car ctl)) (car ctl) (cadr ctl)))))
+          (slynk::make-arglist :required-args (append (list fst) req) :key-p t :keyword-args key))
+        (call-next-method))))

--- a/util.lisp
+++ b/util.lisp
@@ -112,3 +112,8 @@
   (when (alexandria:featurep :swank)
     (load (asdf:system-relative-pathname :cl-collider "swank-extensions.lisp"))))
 
+;; conditionally load slynk extensions
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (when (alexandria:featurep :slynk)
+    (load (asdf:system-relative-pathname :cl-collider "slynk-extensions.lisp"))))
+


### PR DESCRIPTION
This provides the same extensions for [sly/slynk](https://github.com/joaotavora/sly) as were already provided for `swank`.