### PR TITLE
better buffer-get-*, + buffer-to-list and buffer-to-array functions

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -95,6 +95,10 @@
 	   #:buffer-getn
 	   #:buffer-get-to-list
 	   #:buffer-load-to-list
+	   #:buffer-to-list
+	   #:buffer-get-to-array
+	   #:buffer-load-to-array
+	   #:buffer-to-array
 	   #:buffer-set
 	   #:buffer-setn
 	   #:buffer-zero


### PR DESCRIPTION
This change fixes a bug in my previous implementation of `buffer-get-to-list`; it incorrectly limited the maximum number of frames to `(frames buffer)` rather than `(* (chanls buffer) (frames buffer))`.

Additionally, it introduces `buffer-to-list` which forwards to `buffer-load-to-list` by default, or to `buffer-get-to-list` if `buffer-load-to-list` is not available (i.e. non-local server).

It also introduces `buffer-get-to-array`, `buffer-load-to-array` and `buffer-to-array` which are similar to `buffer-get-to-list`, `buffer-load-to-list` and `buffer-to-list`, respectively, except that they return a (possibly multidimensional) array of the buffer's channels, rather than simply a flat list of the interlaced frame data.

i.e. for a 2-channel buffer `*buf*`:

```lisp
;; one channel, single-dimension array of the channel:
(array-dimensions (buffer-to-array *buf* 0 200 0)) ;=> (200)

;; one channel as a list, 2-dimension array of the channel:
(array-dimensions (buffer-to-array *buf* 0 200 '(0))) ;=> (1 200)

;; two channels as a list, 2-dimensional array of the channels:
(array-dimensions (buffer-to-array *buf* 0 200 '(0 1))) ;=> (2 200)

;; defaults to all channels:
(array-dimensions (buffer-to-array *buf* 0 200)) ;=> (2 200)
```

Additionally, for consistency and ease of use, `buffer-getn`, `buffer-get-to-list`, and `buffer-load-to-list` now take START and END as arguments instead of START and FRAMES (as do all `buffer-to-*` and `buffer-get*` functions). This is obviously an incompatible change but judging by the fact that no one noticed these functions were broken, I feel it is unlikely to cause major problems.

Docstrings have been updated and improved to explain the differences between the functions, and each one suggests the best function for the job (i.e. `buffer-to-list` or `buffer-to-array`).