### PR TITLE
Allow use of `synth` inside synthdefs + JPverb

### DIFF
--- a/ugens/SC3plugins/DEINDUGens.lisp
+++ b/ugens/SC3plugins/DEINDUGens.lisp
@@ -4,10 +4,24 @@
     (in &optional (delay-time 2.0) (damp 0.0) (size 1.0) (diff 0.707) (feedback 0.9) (mod-depth 0.1) (mod-freq 2.0))
   ((:ar
     (let ((in (alexandria:ensure-list in)))
-      (multinew new 'multiout-ugen 2 (if (alexandria:length= 1 in)
-					 in
-					 (elt in 0))
+      (multinew new 'multiout-ugen 2
+		(if (alexandria:length= 1 in)
+		    in
+		    (elt in 0))
 		(if (alexandria:length= 1 in)
 		    in
 		    (elt in 1))
 		delay-time damp size diff feedback mod-depth mod-freq)))))
+
+(defugen (jpverb "JPverbRaw")
+    (in &optional (time 1.0) (damp 0.0) (size 1.0) (early-diff 0.707) (mod-depth 0.1) (mod-freq 2.0) (low 1.0) (mid 1.0) (high 1.0) (low-cut 500.0) (high-cut 2000.0))
+  ((:ar
+    (let ((in (alexandria:ensure-list in)))
+      (multinew new 'multiout-ugen 2
+		(if (alexandria:length= 1 in)
+		    in
+		    (elt in 0))
+		(if (alexandria:length= 1 in)
+		    in
+		    (elt in 1))
+		damp early-diff high-cut high low-cut low mod-depth mod-freq mid size time)))))

--- a/util.lisp
+++ b/util.lisp
@@ -35,12 +35,8 @@
 			       (sleep .01))))))
 
 (defun full-pathname (path)
-  "returning absoulte full-pathname of path"
-  (let* ((directory (uiop:truenamize (uiop:pathname-directory-pathname path)))
-	 (filename (pathname-name path))
-	 (filetype (pathname-type path)))
-    (when directory
-      (format nil "~a~@[~a~]~@[.~a~]" (namestring directory) filename filetype))))
+  "Get the absolute pathname of PATH."
+  (uiop:native-namestring path))
 
 (defmethod cat ((sequence string) &rest sequences)
   (apply #'concatenate 'string sequence sequences))


### PR DESCRIPTION
This PR includes the `JPverb` UGen, simplification of `full-pathname`, and the ability to use `synth` inside synthdefs.

Example:

```lisp
(defsynth :mdapiano ((gate 1) (freq 440) (vel 100) (random 0.1) (rel 0.9) (stereo 0.3) (amp 0.5))
  (let* ((sig (/ (mda-piano.ar freq :gate gate :vel vel :release rel :stereo stereo :random random :sustain 0) 2))
         (ds (detect-silence.ar sig 1.0e-4 :act :free)))
    (declare (ignore ds))
    (out.ar 0 (* sig amp))))

(defsynth :tremolo-piano ((gate 1) (freq 440) (amp 0.5))
  (out.ar 0 (* (sin-osc.ar 8 0 0.5 0.5)
               (synth :mdapiano :gate gate :freq freq)
               amp)))
```

Caveats(?):

- The `synth` form will not automatically grab the values of its arguments from the synthdef; they have to be specified. This is similar to how regular function calls work though so it is probably more intuitive this way, albeit maybe less convenient in some cases.
- The embedded synth's unprovided arguments are not automatically promoted to arguments of the enclosing synthdef. This differs from SuperCollider's `SynthDef.wrap` functionality, but again, it is probably more intuitive this way since we are just calling `synth` and not a `synthdef-wrap` function or similar.