### PR TITLE
Improve `env` error messages, fix `buffer-get-to-array`, record server samplerate from `/status.reply`

### DIFF
--- a/buffer.lisp
+++ b/buffer.lisp
@@ -261,7 +261,7 @@ Note that this is a synchronous function, so you should not call it in the reply
 Similar to `buffer-load-to-array' but uses multiple OSC requests to download the buffer, for situations (i.e. non-local servers) where using a temporary file is not possible. Generally `buffer-to-array' is preferred since it automatically picks the fastest available function.
 
 Additionally, since this is a synchronous function, you should not call it in the reply thread."
-  (buffer-to-array buffer start end channels #'buffer-get-to-list))
+  (buffer-to-array buffer :start start :end end :channels channels :get-function #'buffer-get-to-list))
 
 (defun buffer-load-to-array (buffer &key (start 0) (end (frames buffer)) channels)
   "Get an array of CHANNELS containing the frames of BUFFER, from START up to END, defaulting to the entire buffer.

--- a/server.lisp
+++ b/server.lisp
@@ -284,6 +284,7 @@
     (add-reply-responder
      "/status.reply"
      (lambda (&rest args)
+       (setf (server-options-hardware-samplerate (server-options *s*)) (car (last args 2)))
        (apply #'format t "~&UGens    : ~4d~&Synths   : ~4d~&Groups   : ~4d~&SynthDefs: ~4d~&% CPU (Average): ~a~&% CPU (Peak)   : ~a~&SampleRate (Nominal): ~a~&SampleRate (Actual) : ~a~%" (cdr args))
        (force-output)))
     (add-reply-responder

--- a/ugens/EnvGen.lisp
+++ b/ugens/EnvGen.lisp
@@ -62,8 +62,12 @@
 
 (defmethod initialize-instance :after ((self env) &key)
   (with-slots (levels times curve-number release-node loop-node) self
-    (assert (= (1- (length levels)) (length times)))
-    (assert (>= (length times) (length curve-number)))))
+    (assert (= (1- (length levels)) (length times)) (levels times)
+	    "~D times were provided, but the envelope has ~D segments."
+	    (length times) (1- (length levels)))
+    (assert (>= (length times) (length curve-number)) (times curve-number)
+	    "~D curves were provided, but the envelope only has ~D segments."
+	    (length curve-number) (length times))))
 
 (defparameter +env-shape-table+
   (let ((table (make-hash-table)))


### PR DESCRIPTION
Hi,

3 minor improvements/fixes:

- Better error messages when the user attempts to make an invalid `env`
- Fix `buffer-get-to-array`
- Record the server samplerate from `/status.reply`