### PR TITLE
Fix errors when calling `synth' with :pos or :to keywords.

### DIFF
--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -440,6 +440,7 @@
          (pos (or (getf args :pos) :head))
          (new-synth (make-instance 'node :server *s* :id next-id :name name-string :pos pos :to to))
          (args (loop :for (arg val) :on args :by #'cddr
+		     :unless (member arg '(:id :to :pos))
 		     :append (list (string-downcase arg) (floatfy val)))))
     (message-distribute new-synth
 			(apply #'make-synth-msg *s* name-string next-id to pos args)


### PR DESCRIPTION
This fixes the following error:
```
SC-USER> (defsynth test ())
#<CL-COLLIDER::SYNTHDEF :name "test">
SC-USER> (synth 'test :pos :tail)
---> Can't floatify :TAIL
```
or
```
SC-USER> (defparameter *aux-group* (make-group))
*AUX-GROUP*
SC-USER> (synth 'test :to *aux-group*)
---> Can't floatify #<CL-COLLIDER::GROUP :server #<CL-COLLIDER::EXTERNAL-SERVER localhost-127.0.0.1:4444> :id 3>
```

This was a bug introduced [here](https://github.com/byulparan/cl-collider/commit/03ace5af8d4ce62e857a24ccf2c74f81999037aa).