### PR TITLE
implement sc's Group.freeAll

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -62,11 +62,11 @@
 	   #:make-group
 	   #:server-query-all-nodes
 	   #:group-free-all
-	   #:free-all
+	   #:server-free-all
 	   #:stop
 	   #:server-status
 	   #:*server-quit-hooks*
-	   #:*free-all-hooks*
+	   #:*server-free-all-hooks*
 	   #:*stop-hooks*
 
 	   #:now

--- a/package.lisp
+++ b/package.lisp
@@ -62,10 +62,11 @@
 	   #:make-group
 	   #:server-query-all-nodes
 	   #:group-free-all
+	   #:free-all
 	   #:stop
 	   #:server-status
 	   #:*server-quit-hooks*
-	   #:*group-free-all-hooks*
+	   #:*free-all-hooks*
 	   #:*stop-hooks*
 
 	   #:now

--- a/server.lisp
+++ b/server.lisp
@@ -243,7 +243,7 @@
     (sched-run (scheduler rt-server))
     (tempo-clock-run (tempo-clock rt-server))
     (sync rt-server)
-    (free-all rt-server)
+    (server-free-all rt-server)
     (let ((options (server-options rt-server)))
       (setf (id rt-server) (list #-sbcl 999 #+sbcl 1000)
 	    (group-id rt-server) 1
@@ -645,16 +645,17 @@
   (with-node (group id server)
     (send-message server "/g_freeAll" id)))
 
-(defvar *free-all-hooks* nil)
+(defvar *server-free-all-hooks* nil)
 
-(defun free-all (&optional (rt-server *s*))
+(defun server-free-all (&optional (rt-server *s*))
+  "Frees all nodes and clears scheduler on RT-SERVER."
   (let ((*s* rt-server))
     (sched-clear (scheduler rt-server))
     (tempo-clock-clear (tempo-clock rt-server))
     (send-message rt-server "/g_freeAll" 0)
     (send-message rt-server "/clearSched")
     (make-group :id 1 :pos :head :to 0)
-    (dolist (hook *free-all-hooks*)
+    (dolist (hook *server-free-all-hooks*)
       (funcall hook))))
 
 (defvar *stop-hooks* nil)

--- a/server.lisp
+++ b/server.lisp
@@ -243,7 +243,7 @@
     (sched-run (scheduler rt-server))
     (tempo-clock-run (tempo-clock rt-server))
     (sync rt-server)
-    (group-free-all rt-server)
+    (free-all rt-server)
     (let ((options (server-options rt-server)))
       (setf (id rt-server) (list #-sbcl 999 #+sbcl 1000)
 	    (group-id rt-server) 1
@@ -640,16 +640,21 @@
 (defun server-query-all-nodes (&optional (rt-server *s*))
   (send-message rt-server "/g_dumpTree" 0 0))
 
-(defvar *group-free-all-hooks* nil)
+(defun group-free-all (group)
+  "Frees all nodes in GROUP but not GROUP itself."
+  (with-node (group id server)
+    (send-message server "/g_freeAll" id)))
 
-(defun group-free-all (&optional (rt-server *s*))
+(defvar *free-all-hooks* nil)
+
+(defun free-all (&optional (rt-server *s*))
   (let ((*s* rt-server))
     (sched-clear (scheduler rt-server))
     (tempo-clock-clear (tempo-clock rt-server))
     (send-message rt-server "/g_freeAll" 0)
     (send-message rt-server "/clearSched")
     (make-group :id 1 :pos :head :to 0)
-    (dolist (hook *group-free-all-hooks*)
+    (dolist (hook *free-all-hooks*)
       (funcall hook))))
 
 (defvar *stop-hooks* nil)


### PR DESCRIPTION
Implement `group-free-all` as a function that frees all nodes in a group without freeing that group.

Rename the existing `group-free-all` to `free-all`, to better reflect what it does and allow for consistency with sc.

If the latter is too much of a breaking change, I'd be happy to reverse it and give the new function another name. Maybe `free-in-group`?