### PR TITLE
Documentation for `synth`'s arguments.

### DIFF
--- a/swank-extensions.lisp
+++ b/swank-extensions.lisp
@@ -1,7 +1,8 @@
 (in-package #:cl-collider)
 
 ;; make slime show the synthdef's argument list for (synth ...)
-(defmethod swank::compute-enriched-decoded-arglist ((operator-form (eql 'synth)) argument-forms)
+(defmethod swank::compute-enriched-decoded-arglist ((operator-form (eql 'synth))
+                                                    argument-forms)
   (let* ((fst (car argument-forms))
          (controls (unless (typep fst 'swank::arglist-dummy)
                      (synthdef-metadata (if (and (listp fst)
@@ -10,11 +11,22 @@
                                             fst)
                                         :controls))))
     (if controls
-        (let ((req (loop :for ctl :in controls
-                      :if (atom ctl)
-                      :collect ctl))
-              (key (loop :for ctl :in controls
-                      :if (listp ctl)
-                      :collect (swank::make-keyword-arg (alexandria:make-keyword (car ctl)) (car ctl) (cadr ctl)))))
-          (swank::make-arglist :required-args (append (list fst) req) :key-p t :keyword-args key))
+        (loop
+          :for ctl :in controls
+          :if (atom ctl)
+            :collect ctl :into req
+          :if (listp ctl)
+            :collect (swank::make-keyword-arg
+                      (alexandria:make-keyword (car ctl))
+                      (car ctl)
+                      (cadr ctl))
+              :into key
+          :finally
+             (return
+               (swank::make-arglist
+                :required-args (append (list fst) req)
+                :key-p t
+                :keyword-args (append
+                               key
+                               (swank::keywords-of-operator operator-form)))))
         (call-next-method))))

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -432,12 +432,19 @@
          (sync)
          ,node))))
 
-(defun synth (name &rest args)
-  "Start a synth by name."
+(defun synth (name &rest args &key id (pos :head) (to 1) &allow-other-keys)
+  "Start a synth by name.
+
+Optionally takes keyword arguments ID POS and HEAD.
+
+:ID specifies the synths id.
+
+:POS specifies the synths position in the node tree relative to the node passed
+via :TO, possible values are :HEAD, :TAIL, :BEFORE, :AFTER.
+
+:TO passes a node either as a `node' object or node id."
   (let* ((name-string (string-downcase (symbol-name name)))
-         (next-id (or (getf args :id) (get-next-id *s*)))
-         (to (or (getf args :to) 1))
-         (pos (or (getf args :pos) :head))
+         (next-id (or id (get-next-id *s*)))
          (new-synth (make-instance 'node :server *s* :id next-id :name name-string :pos pos :to to))
          (args (loop :for (arg val) :on args :by #'cddr
 		     :unless (member arg '(:id :to :pos))


### PR DESCRIPTION
Document the `ID`, `POS` and `TO` keyword arguments for `synth`. Also make them show up in sly and slime. Should not change usage.