### PR TITLE
`floatfy` env shape symbols

### DIFF
--- a/server.lisp
+++ b/server.lisp
@@ -100,6 +100,12 @@
 (defmethod floatfy ((object string))
   object)
 
+(defmethod floatfy ((object symbol))
+  (env-shape-number object))
+
+(defmethod floatfy ((object list))
+  (mapcar #'floatfy object))
+
 (defgeneric is-local-p (server)
   (:documentation "The scsynth server can run across the network.
  If the server is running on the local machine, return T, otherwise NIL."))


### PR DESCRIPTION
Add a method to `floatfy` for envelope shape name symbols (i.e. `:lin`, `:exp`, etc). This should avoid the error described in #145.

I also added a method to floatfy lists by floatfying each element of the list. This allows users to provide a list of env shapes as well.