### PR TITLE
docstring and formatting cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # cl-collider
 
-A <a href="http://supercollider.github.io/">SuperCollider</a> client for <a href="https://www.common-lisp.net/">CommonLisp</a>.  
+A <a href="http://supercollider.github.io/">SuperCollider</a> client for <a href="https://www.common-lisp.net/">Common Lisp</a>.
 It is an experimental project, so changes to the API are possible.
 
 ## Videos:
+
 - [tempo-clock on cl-collider](https://youtu.be/3Lo7yyZcSzU)   
 - [cl-collider on Windows10](https://youtu.be/pCEfV4jOdUA)  
 - [Tutorial](https://www.youtube.com/watch?v=JivNMDUqNQc) - Due to API changes, this video is deprecated. A new tutorial video is coming soon.  
@@ -19,6 +20,7 @@ It is an experimental project, so changes to the API are possible.
 - [net-tools](https://net-tools.sourceforge.io/) - On Windows, scsynth should bind to a port before sending a message to CL.
 
 ## Contrib:
+
 If you have your own additional libraries, please report me. I will add here.
 
 - [sc-extensions](https://github.com/byulparan/sc-extensions) - extension library
@@ -27,6 +29,7 @@ If you have your own additional libraries, please report me. I will add here.
 - [sc-vst](https://github.com/byulparan/sc-vst) - VSTPlugin support library
 
 ## Usage:
+
 - package: `sc`, `sc-user` (use this package)
 - named-readtable: `sc`
 
@@ -65,6 +68,7 @@ If you have your own additional libraries, please report me. I will add here.
 ```
 
 ### Create SynthDef
+
 ```cl
 (defsynth sine-wave ((note 60))
   (let* ((freq (midicps note))
@@ -77,6 +81,7 @@ If you have your own additional libraries, please report me. I will add here.
 ```
 
 ### Create Proxy
+
 ```cl
 (proxy :sinesynth
   (sin-osc.ar [440 441] 0 .2))
@@ -89,7 +94,9 @@ If you have your own additional libraries, please report me. I will add here.
 (ctrl :sinesynth :lfo-speed 8)
 (ctrl :sinesynth :gate 0)
 ```
+
 ### Create Musical Sequence
+
 ```cl
 (defsynth saw-synth ((note 60) (dur 4.0))
   (let* ((env (env-gen.kr (env [0 .2 0] [(* dur .2) (* dur .8)]) :act :free))
@@ -106,7 +113,9 @@ If you have your own additional libraries, please report me. I will add here.
 (make-melody (quant 4) 16)
 (make-melody (+ 4 (quant 4)) 16 12)
 ```
+
 ### Non-real-time Rendering to File
+
 ```cl
 (setf *synth-definition-mode* :load)
 
@@ -131,7 +140,9 @@ If you have your own additional libraries, please report me. I will add here.
   (make-melody 8.0d0 32 12)
   (make-melody 16.0d0 32 24))
 ```
+
 ### Record Audio Output
+
 ```cl
 ;;; write a single channel to disk
 
@@ -157,7 +168,6 @@ mybuffer
 (proxy :blah (sin-osc.ar 440))
 (free :blah)
 
-
 ;; then when you are done
 
 ;; stop the disk_writer synth
@@ -166,7 +176,6 @@ mybuffer
 ;; close and free the buffer
 (buffer-close mybuffer)
 (buffer-free mybuffer)
-
 
 ;; then you can play what you recorded with a utility like mpv:
 ;;     mpv /tmp/foo.aiff

--- a/bus.lisp
+++ b/bus.lisp
@@ -1,4 +1,3 @@
-
 (in-package #:sc)
 
 (defclass bus ()

--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -76,4 +76,3 @@
 	       (:file "ugens/SC3plugins/TJUGens")
 	       (:file "ugens/quarks/miSCellaneous_lib/WaveFolding")
 	       (:file "ugens/Extensions/mi-ugens")))
-

--- a/id-map.lisp
+++ b/id-map.lisp
@@ -1,6 +1,7 @@
 (in-package #:sc)
 
 ;;; ---id map ------------------------------------
+
 (defstruct id-map
   (vector (make-array 1 :initial-element nil))
   (free 0)

--- a/operators.lisp
+++ b/operators.lisp
@@ -1,6 +1,5 @@
 (in-package #:sc)
 
-
 (defgeneric optimize-sub (ugen))
 (defgeneric optimize-add-neg (ugen))
 (defgeneric optimize-to-madd (ugen))
@@ -27,8 +26,6 @@
 			(if (numberp (second args)) (apply ,basic-function (cdr args))
 			    (apply #'ugen-new "UnaryOpUGen" nil cls #'identity :bipolar args)))))
 	 (multinew ,op-new 'unary-operator ,special-index in1)))))
-
-
 
 (def-unary-op neg (lambda (a) (* -1 a))
   :special-index 0)
@@ -156,7 +153,6 @@
   ((equalp 1.0 in2) in1)
   ((equalp -1.0 in2) (neg in1)))
 
-
 (defun optimize-add (ugen)
   (let ((optimized-ugen (optimize-to-sum3 ugen)))
     (unless optimized-ugen (setf optimized-ugen (optimize-to-sum4 ugen)))
@@ -165,7 +161,6 @@
     (when optimized-ugen
       (replace-ugen (synthdef ugen) ugen optimized-ugen)
       (optimize-graph optimized-ugen))))
-
 
 (defmethod optimize-sub (ugen)
   (destructuring-bind (a b) (inputs ugen)
@@ -192,7 +187,6 @@
 	      (alexandria:removef (descendants x) ugen))
 	  (minus a (nth 0 (inputs b))))))))
 
-
 (defmethod optimize-graph ((ugen binary-operator))
   (when (perform-dead-code-elimination ugen)
     (return-from optimize-graph))
@@ -200,7 +194,6 @@
     (return-from optimize-graph (optimize-add ugen)))
   (when (= (special-index ugen) 1)
     (optimize-sub ugen)))
-
 
 (defun +~ (&rest args)
   (reduce 'add args))
@@ -280,7 +273,6 @@
 (def-binary-op logior~ #'logior
     (:special-index 15))
 
-
 (def-binary-op << #'(lambda (in1 in2) (ash in1 in2))
     (:special-index 26))
 
@@ -292,7 +284,7 @@
       (>> in1 (- in2))))
 ;;;
 ;;;
-;;; 
+;;;
 
 (defclass MulAdd (ugen) ())
 
@@ -378,7 +370,6 @@
 	  (alexandria:removef (children (synthdef ugen)) x)
 	  (sum3 (nth 0 (inputs x)) (nth 1 (inputs x)) y))))))
 
-
 ;;; Sum3
 (defclass sum4 (ugen) ())
 
@@ -411,7 +402,6 @@
 	(when (and x y)
 	  (alexandria:removef (children (synthdef ugen)) x)
 	  (sum4 (nth 0 (inputs x)) (nth 1 (inputs x)) (nth 2 (inputs x)) y))))))
-
 
 ;;; operations ugen
 ;;; UGen 연산자 -------------------------------------------------------------
@@ -524,4 +514,3 @@
 
 (defmethod duplicate ((self function) (n list))
   (loop for i in n collect (funcall self i)))
-

--- a/package.lisp
+++ b/package.lisp
@@ -14,16 +14,16 @@
 	   #:*sc-plugin-paths*
 	   #:*sc-synthdefs-path*
 	   #:+inf+
-	   
+
 	   #+(or linux freebsd) #:jack-connect
 
 	   #:sched-ahead
 	   #:latency
-	   
+
 	   #:make-server-options
 	   #:server-options
 	   #:server-options-block-size
-	   
+
 	   #:*synth-definition-mode*
 	   #:defsynth
 	   #:synth
@@ -42,7 +42,7 @@
 	   #:make-external-server
 	   #:server-boot
 	   #:server-quit
-	   #:boot-p 
+	   #:boot-p
 	   #:send-message
 	   #:send-bundle
 
@@ -51,7 +51,7 @@
 	   #:add-reply-responder
 	   #:remove-reply-responder
 	   #:sync
-	   
+
 	   #:at
 	   #:free
 	   #:release
@@ -82,7 +82,7 @@
 	   #:clock-clear
 	   #:at-beat
 	   #:at-task
-	   
+
 	   #:bufnum
 	   #:sr
 	   #:frames
@@ -111,7 +111,7 @@
 	   #:buffer-normalize
 	   #:buffer-dur
 	   #:buffer-copy
-	   
+
 	   #:buffer-fill
 	   #:buffer-read-as-wavetable
 	   #:calc-pv-recsize
@@ -121,12 +121,14 @@
 	   #:local-buf-list
 	   #:as-wavetable
 	   #:as-wavetable-no-wrap
-	   
+
 	   #:bus-audio
 	   #:bus-control
 	   #:bus-free
 	   #:bus-string
 	   #:busnum
+
+	   #:import-sclang-ugens
 
 	   #:neg
 	   #:reciprocal
@@ -192,5 +194,3 @@
 
 (in-package :sc-user)
 (named-readtables:in-readtable :sc)
-
-

--- a/scheduler.lisp
+++ b/scheduler.lisp
@@ -32,7 +32,6 @@
       (gettimeofday tv (cffi::null-pointer))
       (+ (cffi:mem-ref tv 'time_t) (* (cffi:mem-ref tv 'seconds_t (cffi:foreign-type-size 'time_t)) 1.0d-6)))))
 
-
 #-windows
 (cffi:defcstruct sched-param
     (priority :int))
@@ -86,7 +85,7 @@
   (values))
 
 ;; ================================================================================
-;; threading util 
+;; threading util
 
 #+ecl
 (defmacro with-recursive-lock-held ((lock) &body body)
@@ -110,7 +109,6 @@
 
 #-ecl
 (setf (symbol-function 'condition-wait) #'bt:condition-wait)
-
 
 ;; ================================================================================
 
@@ -221,7 +219,6 @@
     (bt:join-thread (sched-thread scheduler))
     (setf (sched-status scheduler) :stop)))
 
-
 ;;; TempoClock
 (defclass tempo-clock (scheduler)
   ((bpm :initarg :bpm :accessor bpm)
@@ -317,7 +314,6 @@
       (loop :until (pileup:heap-empty-p in-queue)
 	    :do (pileup:heap-pop in-queue)))
     (bt:condition-notify (condition-var tempo-clock))))
-
 
 (defmethod tempo-clock-quant ((tempo-clock tempo-clock) quant)
   (let* ((beats (secs-to-beats tempo-clock (+ (sched-ahead (server tempo-clock)) (sched-time tempo-clock)))))

--- a/server-options.lisp
+++ b/server-options.lisp
@@ -22,39 +22,37 @@
   (verbosity 0)
   (ugen-plugins-path (mapcar #'full-pathname *sc-plugin-paths*))
   (device nil))
-  
 
 (defun build-server-options (server-options)
   (reduce #'append
-    (mapcar (lambda (pair)
-              (let ((param-name (first pair))
-                    (param-value (funcall (second pair) server-options)))
-                (when param-value
-                  (list param-name
-                        (if (stringp param-value)
-                          param-value
-                          (write-to-string param-value))))))
-            (list '("-c" server-options-num-control-bus)
-                  '("-a" server-options-num-audio-bus)
-                  '("-i" server-options-num-input-bus)
-                  '("-o" server-options-num-output-bus)
-                  '("-z" server-options-block-size)
-                  '("-S" server-options-hardware-samplerate)
-                  '("-b" server-options-num-sample-buffers)
-                  '("-n" server-options-max-num-nodes)
-                  '("-d" server-options-max-num-synthdefs)
-                  '("-m" server-options-realtime-mem-size)
-                  '("-w" server-options-num-wire-buffers)
-                  '("-r" server-options-num-random-seeds)
-                  '("-D" server-options-load-synthdefs-p)
-                  '("-R" server-options-publish-to-rendezvous-p)
-                  '("-l" server-options-max-logins)
-                  '("-V" server-options-verbosity)
-                  '("-H" server-options-device)))
-             
-    :initial-value (let* ((paths (server-options-ugen-plugins-path server-options)))
-                       (if (not paths) nil
-                        (list "-U" (format nil
-                                    #-windows "~{~a~^:~}"
-                                                 #+windows "~{~a~^;~}"
-                                    paths))))))
+	  (mapcar (lambda (pair)
+		    (let ((param-name (first pair))
+			  (param-value (funcall (second pair) server-options)))
+		      (when param-value
+			(list param-name
+			      (if (stringp param-value)
+				  param-value
+				  (write-to-string param-value))))))
+		  (list '("-c" server-options-num-control-bus)
+			'("-a" server-options-num-audio-bus)
+			'("-i" server-options-num-input-bus)
+			'("-o" server-options-num-output-bus)
+			'("-z" server-options-block-size)
+			'("-S" server-options-hardware-samplerate)
+			'("-b" server-options-num-sample-buffers)
+			'("-n" server-options-max-num-nodes)
+			'("-d" server-options-max-num-synthdefs)
+			'("-m" server-options-realtime-mem-size)
+			'("-w" server-options-num-wire-buffers)
+			'("-r" server-options-num-random-seeds)
+			'("-D" server-options-load-synthdefs-p)
+			'("-R" server-options-publish-to-rendezvous-p)
+			'("-l" server-options-max-logins)
+			'("-V" server-options-verbosity)
+			'("-H" server-options-device)))
+	  :initial-value (let* ((paths (server-options-ugen-plugins-path server-options)))
+			   (when paths
+			     (list "-U" (format nil
+						#-windows "~{~a~^:~}"
+						#+windows "~{~a~^;~}"
+						paths))))))

--- a/server.lisp
+++ b/server.lisp
@@ -34,7 +34,7 @@
   #+(or linux freebsd) (remove-if-not #'uiop:directory-exists-p '("/usr/local/lib/SuperCollider/plugins/"
                                                                   "/usr/lib/SuperCollider/plugins/"
                                                                   "/usr/local/share/SuperCollider/Extensions/"
-                                                                  "/usr/share/SuperCollider/Extensions/"))      
+                                                                  "/usr/share/SuperCollider/Extensions/"))
   #+windows (list (merge-pathnames #P"plugins/" *win-sc-dir*)
 		  (full-pathname (merge-pathnames #P"SuperCollider/Extensions/"
 						  (uiop:get-folder-path :local-appdata)))))
@@ -79,7 +79,6 @@
   #+ecl (bt:with-lock-held ((server-lock server))
 	  (incf (car (id server))))
   #+lispworks (system:atomic-incf (car (id server))))
-
 
 ;;; declare generic function for realtime server
 (defgeneric floatfy (object)
@@ -143,6 +142,7 @@
 ;;; -------------------------------------------------------
 ;;; realtime Server
 ;;; -------------------------------------------------------
+
 (defgeneric install-reply-responder (rt-server cmd handler))
 (defgeneric uninstall-reply-responder (rt-server cmd))
 (defgeneric bootup-server-process (rt-server))
@@ -354,8 +354,6 @@
     (add-reply-responder
      "/d_removed" (lambda (&rest args) (declare (ignore args))))))
 
-
-
 (defun control-get (index &optional action)
   (let ((result nil)
 	(index (floor (floatfy index))))
@@ -368,7 +366,6 @@
 (defun control-set (index value)
   (message-distribute nil (list "/c_set" (floatfy index) value) *s*))
 
-
 #+(or linux freebsd)
 (defun jack-connect (&key (client-name "SuperCollider") (input-name "system:capture") (output-name "system:playback"))
   (loop for i from 0 below (server-options-num-input-bus (server-options *s*))
@@ -378,14 +375,12 @@
 	do (uiop:run-program (format nil "jack_connect ~a:out_~d ~a_~d" client-name (+ i 1) output-name (+ i 1))
 			     :ignore-error-status t)))
 
-
-
 ;;; --------------------------------------------------------------------------------------------
 ;;; external server
 ;;; --------------------------------------------------------------------------------------------
 
 (defclass external-server (rt-server)
-  ((host 
+  ((host
     :initarg :host
     :reader host)
    (port
@@ -413,12 +408,12 @@
 (defmethod bootup-server-process ((rt-server external-server))
   (unless (just-connect-p rt-server)
     (setf (sc-thread rt-server)
-      (bt:make-thread
-       (lambda () (sc-program-run (full-pathname *sc-synth-program*)
-                                  (append
-                                   (list "-u" (write-to-string (port rt-server)))
-                                   (build-server-options (server-options rt-server)))))
-       :name "scsynth")))
+	  (bt:make-thread
+	   (lambda () (sc-program-run (full-pathname *sc-synth-program*)
+				      (append
+				       (list "-u" (write-to-string (port rt-server)))
+				       (build-server-options (server-options rt-server)))))
+	   :name "scsynth")))
   #+windows (sleep 2) ;; Wait on server boot...It's very temporal.
   (with-slots (osc-device) rt-server
     (setf osc-device (sc-osc:osc-device (host rt-server) (port rt-server) :local-port 0))))
@@ -437,7 +432,6 @@
 				   (sched-stop (scheduler rt-server))
 				   (tempo-clock-stop (tempo-clock rt-server)))
     (call-next-method)))
-
 
 (defmethod install-reply-responder ((rt-server external-server) cmd-name f)
   (sc-osc:add-osc-responder (osc-device rt-server) cmd-name f))
@@ -464,7 +458,6 @@
 		 :host host
 		 :port port
 		 :just-connect-p just-connect-p))
-
 
 ;; cleanup server
 (labels ((cleanup-server ()
@@ -552,6 +545,7 @@
 ;;; -------------------------------------------------------
 ;;; Node
 ;;; -------------------------------------------------------
+
 (defclass node ()
   ((server :initarg :server :reader server)
    (id :initarg :id :reader id)
@@ -691,13 +685,11 @@
                     (apply f args))
       (apply f args))))
 
-
 (defun now ()
   (sched-time (scheduler *s*)))
 
 (defun quant (next-time &optional (offset .5))
   (sched-quant (scheduler *s*) next-time offset))
-
 
 ;;; tempo-clock
 (defun set-clock (new-clock)
@@ -728,8 +720,6 @@
 
 (defun clock-clear ()
   (tempo-clock-clear (tempo-clock *s*)))
-
-
 
 (defmacro at-beat (beat &body body)
   `(at (beats-to-secs (tempo-clock *s*) ,beat)

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -361,7 +361,7 @@
 	metadata)))
 
 #-ecl
-(uiop:with-deprecation (:style-warning)
+(uiop:with-deprecation (:warning)
   (defun get-synthdef-metadata (synth &optional key)
     "Deprecated alias for `synthdef-metadata'."
     (synthdef-metadata synth key)))
@@ -371,7 +371,7 @@
   (setf (getf (gethash (as-keyword synth) *synthdef-metadata*) (as-keyword key)) value))
 
 #-ecl
-(uiop:with-deprecation (:style-warning)
+(uiop:with-deprecation (:warning)
   (defun set-synthdef-metadata (synth key value)
     "Deprecated alias for `(setf synthdef-metadata)'."
     (setf (synthdef-metadata synth key) value)))

--- a/ugen.lisp
+++ b/ugen.lisp
@@ -1,4 +1,3 @@
-
 (in-package #:sc)
 
 ;;; header ---------------------------------------------------------------------------------------------------------
@@ -6,7 +5,7 @@
 (defvar *synthdef* nil)
 
 (defconstant +inf+
-  #+(or ccl lispworks) 1F++0 
+  #+(or ccl lispworks) 1F++0
   #+sbcl sb-ext:single-float-positive-infinity
   #+ecl ;; ext:single-float-positive-infinity // this is right value. but it signal a #<FLOATING-POINT-OVERFLOW>. maybe it's ecl's bug
   ext::most-positive-single-float)
@@ -72,6 +71,7 @@
     (apply #'new1 ugen inputs)))
 
 ;;; UGen rate -------------------------------------------------------------------------------
+
 (defun rate-number (rate)
   (ecase (rate rate)
     (:audio 2)
@@ -195,7 +195,6 @@
     (make-available desc))
   (push ugen stack))
 
-
 (defun make-pstring (string)
   (flex:with-output-to-sequence (vec)
     (write-byte (length string) vec)
@@ -205,7 +204,7 @@
   (mapcar (lambda (in)
 	    (if (typep in 'ugen)
 		(list (synth-index (source in)) (output-index in))
-	        (list -1 (position (floatfy in) (constants (synthdef ugen))))))
+		(list -1 (position (floatfy in) (constants (synthdef ugen))))))
 	  (inputs ugen)))
 
 (defmethod write-def-ugen-version1 ((ugen ugen) stream)
@@ -234,8 +233,6 @@
 						 :initial-element (rate-number ugen))
 		  stream))
 
-
-
 ;;; check inputs ----------------------------------------------------------------------------------------
 
 (defun check-n-inputs (ugen n)
@@ -253,17 +250,16 @@
   (unless (eql (rate ugen) (rate (car (inputs ugen))))
     (error "~a's rate does not match ~a's rate." ugen (car (inputs ugen)))))
 
-
 ;;; UGEN CLASS ------------------------------------------------------------------------------
 
-;;; pure ugen -------------------------------------------------------------------------------
+;;; PureUGen --------------------------------------------------------------------------------
 
 (defclass pure-ugen (ugen) ())
 
 (defmethod optimize-graph ((ugen pure-ugen))
   (perform-dead-code-elimination ugen))
 
-;;; MultioutUgen ----------------------------------------------------------------------------
+;;; MultiOutUGen ----------------------------------------------------------------------------
 
 (defclass proxy-output (ugen)
   ((source :initarg :source :reader source)
@@ -313,7 +309,7 @@
   "Return the 'description' section of a SCDoc helpfile, stripped of tags."
   (ppcre:regex-replace-all
    ;; remove double spaces
-   "  " 
+   "  "
    (ppcre:regex-replace-all
     ;; remove SCDoc tags
     ;; TODO: better treatment of lists, notes and footnotes
@@ -333,7 +329,6 @@
   (alexandria:when-let ((file (sc-help-file sc-name)))
     (parse-description (alexandria:read-file-into-string file
 							 :external-format :utf-8))))
-
 
 ;;; ------------------------------------------------------------------------------------------
 ;;; definition synth

--- a/util.lisp
+++ b/util.lisp
@@ -2,7 +2,6 @@
 (in-package #:sc)
 (named-readtables:in-readtable :sc)
 
-
 ;;; [1 2 3] == (list 1 2 3)
 (let ((rpar (get-macro-character #\))))
   (set-macro-character #\] rpar)
@@ -49,7 +48,6 @@
 (defmethod cat ((sequence list) &rest sequences)
   (apply #'append sequence sequences))
 
-
 (defun sc-program-run (program options)
   #+(or ecl lispworks)
   (uiop:run-program (format nil "~{~s ~}" (cons program options))
@@ -57,7 +55,6 @@
   #-(or ecl lispworks)
   (simple-inferiors:run program options
 			:output t :error t :copier :line))
-
 
 (defun as-keyword (object)
   (alexandria:make-keyword
@@ -101,9 +98,6 @@
   (when (alexandria:featurep :slynk)
     (load (asdf:system-relative-pathname :cl-collider "slynk-extensions.lisp"))))
 
-
-
-
 (defun write-mono-fl32-wav (stream sr sequence)
   "write sequence data to wave file."
   (write-sequence (flexi-streams:string-to-octets "RIFF") stream)
@@ -121,6 +115,3 @@
   (write-sequence (nreverse (osc::encode-int32 (* 4 (length sequence)))) stream)
   (dotimes (i (length sequence))
     (write-sequence (nreverse (osc::encode-float32 (float (elt sequence i) 1.0))) stream)))
-
-
-


### PR DESCRIPTION
This is mostly just various cleanups for code formatting (indentation, spacing, consistency, etc) and a few docstrings/error messages.

I also increased the deprecation level of `get-synthdef-metadata` and `set-synthdef-metadata` to produce warnings instead of style-warnings. Based on a search on github there are a few repos still using the deprecated versions of these functions so gradual deprecation is probably better than removing them outright.