### PR TITLE
add `WarpZ` ugen, remove use of `simple-inferiors`, delete a mistake i made in the previous PR

### DIFF
--- a/cl-collider.asd
+++ b/cl-collider.asd
@@ -12,7 +12,6 @@
 	       #:flexi-streams
 	       #:split-sequence
 	       #:named-readtables
-	       #-(or ecl lispworks) #:simple-inferiors
 	       #:cl-ppcre)
   :serial t
   :components ((:file "package")

--- a/package.lisp
+++ b/package.lisp
@@ -128,8 +128,6 @@
 	   #:bus-string
 	   #:busnum
 
-	   #:import-sclang-ugens
-
 	   #:neg
 	   #:reciprocal
 	   #:frac

--- a/ugens/GrainUGens.lisp
+++ b/ugens/GrainUGens.lisp
@@ -28,9 +28,17 @@
 	      mul add))))
 
 (defugen (warp1 "Warp1") (&optional (numchan 1) (bufnum 0) (pointer 0) (freq-scale 1) (window-size 0.2)
-				    (envbufnum -1) (overlaps 8) (window-rand-ratio 0.0) (interp 1) 
+				    (envbufnum -1) (overlaps 8) (window-rand-ratio 0.0) (interp 1)
 				    &key (mul 1.0) (add 0.0))
   ((:ar (madd (multinew new 'multiout-ugen numchan bufnum pointer freq-scale window-size envbufnum overlaps
-			window-rand-ratio interp) 
+			window-rand-ratio interp)
+	      mul add))))
+
+(defugen (warpz "WarpZ") (&optional (numchan 1) (bufnum 0) (pointer 0) (freq-scale 1)
+				    (window-size 0.2) (envbufnum -1) (overlaps 8) (window-rand-ratio 0.0)
+				    (interp 1) (zero-search 0) (zero-start 0) (mul 1) (add 0))
+  ((:ar (madd (multinew new 'multiout-ugen numchan bufnum pointer freq-scale
+			window-size envbufnum overlaps window-rand-ratio interp
+			zero-search zero-start)
 	      mul add))))
 

--- a/util.lisp
+++ b/util.lisp
@@ -53,8 +53,8 @@
   (uiop:run-program (format nil "~{~s ~}" (cons program options))
 		    :output :interactive)
   #-(or ecl lispworks)
-  (simple-inferiors:run program options
-			:output t :error t :copier :line))
+  (uiop:run-program (cons program options)
+		    :output *debug-io* :error-output *debug-io*))
 
 (defun as-keyword (object)
   (alexandria:make-keyword


### PR DESCRIPTION
This PR:

- adds the `WarpZ` UGen (it's similar to `Warp1`)
- removes the use of `simple-inferiors` (apparently what it was used for can be done just by providing `uiop:run-program` arguments like `:output *debug-io* :error-output *debug-io*`)
- deletes an export from the `defpackage` that i mistakenly added to #152 