### PR TITLE
[WIP] Automatic UGen importing via sclang

### DIFF
--- a/dump-ugens.scd
+++ b/dump-ugens.scd
@@ -1,0 +1,157 @@
+/*
+	Dump SuperCollider UGens as Common Lisp-compatible s-expressions.
+
+	This file is part of cl-collider.
+
+	UGens are dumped using the sclang binary included with SuperCollider. They are dumped as s-expressions rather than defugen forms in order to, if needed, allow UGen data to be manipulated in Lisp prior to generating the defugen.
+
+	Typically you would run this from Lisp by calling:
+	(cl-collider:auto-generate-defugens)
+
+	If you need to call this script from the command line, run something like this:
+	sclang -u 57920 dump-ugens.scd dumped-ugens.lisp
+	...Where:
+	- 57920 is the UDP port for the temporary sclang instance to listen on (to avoid conflicts with existing sclang processes).
+	- dump-ugens.scd is the path to this script.
+	- dumped-ugens.lisp is the filename to write the UGen s-expressions to.
+
+	One caveat of this approach is that ALL UGens are dumped. Potential problems of importing all UGens with this script:
+	- Those which are only defined as sclang code are included. These obviously cannot be run from Lisp.
+	- Some UGens (such as Out, DynKlank, etc) require special code to handle.
+	The solution is that some UGens should be ignored rather than auto-generated on the Lisp side. Refer to the cl-collider variable *auto-generate-ugen-exclusions* for this.
+
+	Related information:
+	- https://github.com/sonoro1234/Lua2SC/blob/master/lua2SC/genugens/scugendumpjson.scd - the script that this one was inspired by.
+	- https://github.com/byulparan/cl-collider/issues/46 - "documentation on Emacs"
+	- https://github.com/supercollider/supercollider/issues/2300 - "UGen metadata system"
+*/
+
+{
+	var rate_types, sc_to_lisp, outputfile, out;
+
+	rate_types = [\ir, \kr, \ar];
+
+	sc_to_lisp = {
+		| object |
+		switch(object.class,
+			Nil, {
+				"nil"; // i'm not sure, but let's hope this won't cause conflicts with False.
+			},
+			True, {
+				"t";
+			},
+			False, {
+				"nil";
+			},
+			Symbol, {
+				(":" ++ object.asString);
+			},
+			Array, {
+				var res = "(";
+				object.do({
+					| elem index |
+					if(index != 0, {
+						res = res ++ " ";
+					});
+					res = res ++ sc_to_lisp.(elem);
+				});
+				res = res ++ ")";
+				res;
+			},
+			{
+				// Floats, Integers, and Strings are the same in Lisp as they are in SC.
+				// anything else, we cross our fingers and hope for the best.
+				if([Float, Integer, String].includes(object.class).not, {
+					"Printing compileString for unexpected class %: %".format(object.class, object.cs).warn;
+				});
+				object.cs;
+			});
+	};
+
+	out = {
+		| output |
+		outputfile.write(output);
+	};
+
+	#[\internal, \local].do({ // use a non-default port to avoid conflicts with already-running servers.
+		| s |
+		s = Server.perform(s);
+		s.addr_(NetAddr("127.0.0.1", 57930)); // use a non-default port to attempt to avoid conflicts with already-running scsynth processes.
+	});
+
+	s.waitForBoot({
+		if(thisProcess.argv.size < 1, {
+			"You must specify an output file as a command line argument to the script.\nFor example: scsynth -u 57920 dump-ugens.scd dumped-ugens.lisp".error;
+			s.quit;
+			1.exit;
+		}, {
+			outputfile = File(thisProcess.argv[0], "w");
+		});
+
+		UGen.allSubclasses.sort({
+			| a b |
+			a.name < b.name;
+		}).do({
+			| ugen_name |
+			var parent, supported_methods, method, arg_names, arg_defaults, arg_string, documentation, doc_summary, doc_categories, doc_related, doc_keywords, doc_class_methods, doc_instance_methods, doc_private_class_methods, doc_private_instance_methods, doc_undocumented_class_methods, doc_undocumented_instance_methods;
+			parent = ugen_name.superclass;
+			supported_methods = rate_types.select({
+				| rate_type |
+				ugen_name.class.findRespondingMethodFor(rate_type).notNil;
+			});
+			method = ugen_name.class.findRespondingMethodFor(supported_methods.first);
+			if(method.notNil, {
+				arg_names = method.argNames.copyRange(1, method.argNames.size);
+				arg_defaults = method.prototypeFrame.copyRange(1, method.prototypeFrame.size);
+				ugen_name.postcs;
+				arg_names.postcs;
+				if(arg_names.size == 0, {
+					arg_string = "()";
+				}, {
+					arg_string = sc_to_lisp.([
+						arg_names.collect({
+							| arg_name |
+							arg_name.asString;
+						}),
+						arg_defaults
+					].flop);
+				});
+			});
+			documentation = SCDoc.documents.at("Classes/"++ugen_name.asString);
+			if(documentation.notNil, {
+				doc_summary = documentation.summary;
+				doc_categories = documentation.categories;
+				doc_related = documentation.related;
+				doc_keywords = documentation.keywords;
+				doc_class_methods = documentation.doccmethods;
+				doc_instance_methods = documentation.docimethods;
+				doc_private_class_methods = documentation.privcmethods;
+				doc_private_instance_methods = documentation.privimethods;
+				doc_undocumented_class_methods = documentation.undoccmethods;
+				doc_undocumented_instance_methods = documentation.undocimethods;
+			});
+			out.("(:ugen \"%\" :superclass \"%\" :methods % :arguments % :summary % :categories % :related % :keywords %)\n\n".format( // :class-methods % :instance-methods :private-class-methods % :private-instance-methods % :undocumented-class-methods % :undocumented-instance-methods %
+				ugen_name,
+				parent,
+				sc_to_lisp.(supported_methods),
+				arg_string,
+				sc_to_lisp.(doc_summary),
+				sc_to_lisp.(doc_categories),
+				sc_to_lisp.(doc_related),
+				sc_to_lisp.(doc_keywords),
+				// sc_to_lisp.(doc_class_methods),
+				// sc_to_lisp.(doc_instance_methods),
+				// sc_to_lisp.(doc_private_class_methods),
+				// sc_to_lisp.(doc_private_instance_methods),
+				// sc_to_lisp.(doc_undocumented_class_methods),
+				// sc_to_lisp.(doc_undocumented_instance_methods),
+			));
+		});
+
+		outputfile.close;
+		s.quit;
+		0.exit;
+
+	});
+
+}.value;

--- a/package.lisp
+++ b/package.lisp
@@ -128,6 +128,8 @@
 	   #:bus-string
 	   #:busnum
 
+	   #:import-sclang-ugens
+
 	   #:neg
 	   #:reciprocal
 	   #:frac


### PR DESCRIPTION
**NOTE:** This is a work-in-progress. Please don't merge this yet as it probably should have testing and discussion.

This is an attempt to make it possible to automatically import (most) UGens from SuperCollider. It does so by using `dump-ugens.scd`, a `sclang` script that dumps all UGens that `sclang` is aware of as `defugen` forms to a temp file, which is then `load`ed into the Lisp image, and thus cl-collider.

Currently, this is NOT done automatically--users have to call `import-sclang-ugens` in order to import UGens from sclang. However, maybe in the future, when this has had more testing, it might be better and less error-prone to automatically import most (but not all) UGens, rather than manually writing `defugen`s, since that would require much less manual effort, and it could also be much less error-prone. Right now, this is probably best for "filling in the gaps" and importing UGens that aren't already defined in cl-collider.

For more details about how this works, refer to the comment at the top of `dump-ugens.scd`, and the docstrings of `auto-generate-defugens` and `import-sclang-ugens`.

A few relevant links:
- https://github.com/sonoro1234/Lua2SC/blob/master/lua2SC/genugens/scugendumpjson.scd - the script that this one was inspired by.
- https://github.com/supercollider/supercollider/issues/2300
  - https://github.com/supercollider/supercollider/issues/4351

A few questions/issues with this code right now:

1. cl-collider uses different names for UGens than SuperCollider does. Might not be a problem since `import-sclang-ugens` has an `:exclude` argument, which allows skipping UGens. Right now it defaults to the value of `*auto-generate-ugen-exclusions*` which is currently just a list of "special" UGens that can't be automatically imported (i.e. "abstract" UGens like `MultiOutUGen`, UGens with unusual input types like `DynKlang`, etc).

`import-sclang-ugens` also has an `:overwrite-existing` argument, defaulting to `nil`, which allows overwriting already-defined ugens (other than the exclusions specified with `:exclude`). Being able to just use this to skip UGens with manually-written `defugen` forms would be the ideal, but since cl-collider uses different names for UGens than SuperCollider does, it won't be able to automatically skip all of them.

2. `import-sclang-ugens` uses the internal function `ugen-already-defined-p` to determine if a UGen is already defined. This function is a bit hacky though; it just checks if `UGEN-NAME.RATE` is a defined symbol. It might be better if UGens are kept track of in a list, perhaps by altering the `defugen` macro to add each defined UGen to said list. This obviously would not be difficult to add.

3. Docstrings. `defugen` currently does not support them. If `:documentation` was added as an additional keyword argument, UGen documentation could also be scraped from sclang. I will probably implement that as a future commit in this PR as I don't think anyone would disagree with that. Related issue: https://github.com/byulparan/cl-collider/issues/46

4. I have not tested `import-sclang-ugens` on Windows or macOS. Ideally it could be verified working on those platforms before this PR is merged, but it's not a high priority for that to be done, since `import-sclang-ugens` doesn't have to be mandatory--for now at least, it could just be an option for users who want to use UGens that cl-collider doesn't already have defined, but don't want to have to write the `defugen` forms themselves. It's possible that `import-sclang-ugens` might "just work" for many such UGens.

5. UGens which are defined as sclang code, rather than actual UGens that the server is aware of (i.e. "pseudo-ugens") will also be dumped. These obviously cannot be run from Lisp, and until we have some way to auto-translate sclang code to Lisp code, it's not possible. I don't think it's really worth the effort to implement something like that though.

6. The code still needs to be cleaned up, and there are still some bugs and missing features in it. For example, it doesn't properly handle `PV_` ugens right now, since they aren't defined with `defugen` but rather `def-pv-chain-ugen`.

7. If you have any other issues with the current state of the PR, or if what's here currently is broken for you in some way I haven't already listed, let me know.

With regard to point 1, personally I would prefer it if cl-collider used the same names for UGens that SuperCollider does. While it's nice to have UGen names that follow Lisp conventions, it's not always easy to guess which ones differ and how. For example, `lag2` vs `lag-2ud` vs `lpz-1` vs `freeverb2`. If cl-collider used the same names as SuperCollider, sclang code would be easier to translate, and it would be easier for new users to learn cl-collider by referencing the standard SC documentation. It would be easy to set the importer to change `_` to `-` during import (i.e. for the `PV_` UGens) if we want to avoid `_`, which I think would be good, but for UGens that don't have `_` in their name, it's not easy to predict whether their name will have `-` in cl-collider, and if so, where they will have `-`.

Obviously, simply removing `sin-osc` in favor of `sinosc` wouldn't be a good idea, since there is already a good amount of code written that depends on the way UGens are currently named, but it would be relatively trivial to alias names like `sin-osc` to `sinosc`. We probably don't even have to deprecate them, since it's unlikely that such names would ever cause symbol conflicts.

Any thoughts, ideas, etc--on the PR, or on the idea of using standard SuperCollider UGen names--are appreciated.