### PR TITLE
Setting a default for hardware-buffer-size so audio server starts on OSX #176

### DIFF
--- a/server-options.lisp
+++ b/server-options.lisp
@@ -8,7 +8,7 @@
   (num-input-bus 8)
   (num-output-bus 8)
   (block-size 64)
-  (hardware-buffer-size 0)
+  (hardware-buffer-size 512)
   (hardware-samplerate 0)
   (num-sample-buffers 1024)
   (max-num-nodes 1024)


### PR DESCRIPTION
This fixes #176 