### PR TITLE
move nodes and group head & tail #134

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -63,13 +63,18 @@
 	   #:map-bus
 	   #:is-playing-p
 
+       #:move-before
+       #:move-after
+       #:move-node-to-head
+       #:move-node-to-tail
+       
 	   #:make-group
 	   #:server-query-all-nodes
 	   #:group-free-all
 	   #:server-free-all
 	   #:stop
 	   #:server-status
-           #:*server-boot-hooks*
+       #:*server-boot-hooks*
 	   #:*server-quit-hooks*
 	   #:*server-free-all-hooks*
 	   #:*stop-hooks*

--- a/package.lisp
+++ b/package.lisp
@@ -62,11 +62,7 @@
 	   #:ctrl
 	   #:map-bus
 	   #:is-playing-p
-       #:move-before
-       #:move-after
-       #:move-to-head
-       #:move-to-tail
-       
+
 	   #:make-group
 	   #:server-query-all-nodes
 	   #:group-free-all

--- a/package.lisp
+++ b/package.lisp
@@ -62,7 +62,11 @@
 	   #:ctrl
 	   #:map-bus
 	   #:is-playing-p
-
+       #:move-before
+       #:move-after
+       #:move-to-head
+       #:move-to-tail
+       
 	   #:make-group
 	   #:server-query-all-nodes
 	   #:group-free-all

--- a/server-options.lisp
+++ b/server-options.lisp
@@ -8,7 +8,7 @@
   (num-input-bus 8)
   (num-output-bus 8)
   (block-size 64)
-  (hardware-buffer-size 512)
+  (hardware-buffer-size 0)
   (hardware-samplerate 0)
   (num-sample-buffers 1024)
   (max-num-nodes 1024)

--- a/server-options.lisp
+++ b/server-options.lisp
@@ -8,7 +8,7 @@
   (num-input-bus 8)
   (num-output-bus 8)
   (block-size 64)
-  (hardware-buffer-size 0)
+  (hardware-buffer-size 512)
   (hardware-samplerate 0)
   (num-sample-buffers 1024)
   (max-num-nodes 1024)

--- a/server.lisp
+++ b/server.lisp
@@ -373,7 +373,15 @@
        (declare (ignore args))
        (alexandria:removef (node-watcher rt-server) id)))
     (add-reply-responder
-     "/d_removed" (lambda (&rest args) (declare (ignore args))))))
+     "/d_removed" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/g_head" (lambda (&rest args) (declare (ignore args)))
+    (add-reply-responder
+     "/g_tail" (lambda (&rest args) (declare (ignore args)))
+    (add-reply-responder
+     "/n_before" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/n_after" (lambda (&rest args) (declare (ignore args))))))
 
 (defun control-get (index &optional action)
   (let ((result nil)
@@ -623,6 +631,43 @@
 										  (t (floatfy p))))
                                                                 param))
                         server)))
+
+;; move nodes
+
+(defun move-after (node before-node)
+  (with-node (node id server)
+    (with-node (before-node b-id server2)
+      (send-message server "/n_after" id b-id))))
+
+(defun move-after (node after-node)
+  (send-message *s* "/n_after" node
+  
+  (let ((id)
+        (after-id))
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (after-node aid server)
+      (setf after-id aid)
+      (send-message server "/n_after" id after-id))))
+
+(defun move-to-head (group node)
+  (let ((id)
+        (group-id))
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (group gid server)
+      (setf group-id gid))
+    (send-message server "g_head" group-id id)))
+
+(defun move-to-tail (group node)
+  (let ((id)
+        (group-id))
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (group gid server)
+      (setf group-id gid))
+    (send-message server "g_tail" group-id id)))
+
 
 (defmethod free ((node node))
   (with-node (node id server)

--- a/server.lisp
+++ b/server.lisp
@@ -375,13 +375,7 @@
     (add-reply-responder
      "/d_removed" (lambda (&rest args) (declare (ignore args))))
     (add-reply-responder
-     "/g_head" (lambda (&rest args) (declare (ignore args))))
-    (add-reply-responder
-     "/g_tail" (lambda (&rest args) (declare (ignore args))))
-    (add-reply-responder
-     "/n_before" (lambda (&rest args) (declare (ignore args))))
-    (add-reply-responder
-     "/n_after" (lambda (&rest args) (declare (ignore args))))))
+     "/n_move" (lambda (&rest args) (declare (ignore args))))))
 
 (defun control-get (index &optional action)
   (let ((result nil)
@@ -634,12 +628,19 @@
 
 ;; move nodes
 
-(defun move-after (node before-node)
-  (with-node (node id server)
-    (with-node (before-node b-id server2)
-      (send-message server "/n_after" id b-id))))
+(defun move-before (node before-node)
+  "Move first node before the second node"
+  (let ((id)
+        (before-id))
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (before-node aid server)
+      (setf before-id aid)
+      (send-message server "/n_before" id before-id))))
 
-(defun move-after (node after-node)  
+  
+(defun move-after (node after-node)
+  "Move first node after the second node"
   (let ((id)
         (after-id))
     (cl-collider::with-node (node cid server)
@@ -648,24 +649,25 @@
       (setf after-id aid)
       (send-message server "/n_after" id after-id))))
 
-(defun move-to-head (group node)
-  (let ((id)
-        (group-id))
-    (cl-collider::with-node (node cid server)
-      (setf id cid))
+(defun move-node-to-head (group node)
+    "Move first node after the second node"
+  (let ((group-id)
+        (node-id))
     (cl-collider::with-node (group gid server)
       (setf group-id gid))
-    (send-message server "g_head" group-id id)))
+    (cl-collider::with-node (node id server)
+      (setf node-id id)
+      (send-message server "/g_head" group-id node-id))))
 
-(defun move-to-tail (group node)
-  (let ((id)
-        (group-id))q
-    (cl-collider::with-node (node cid server)
-      (setf id cid))
+(defun move-node-to-tail (group node)
+    "Move first node after the second node"
+  (let ((group-id)
+        (node-id))
     (cl-collider::with-node (group gid server)
       (setf group-id gid))
-    (send-message server "g_tail" group-id id)))
-
+    (cl-collider::with-node (node id server)
+      (setf node-id id)
+      (send-message server "/g_tail" group-id node-id))))
 
 (defmethod free ((node node))
   (with-node (node id server)

--- a/server.lisp
+++ b/server.lisp
@@ -373,15 +373,7 @@
        (declare (ignore args))
        (alexandria:removef (node-watcher rt-server) id)))
     (add-reply-responder
-     "/d_removed" (lambda (&rest args) (declare (ignore args))))
-    (add-reply-responder
-     "/g_head" (lambda (&rest args) (declare (ignore args)))
-    (add-reply-responder
-     "/g_tail" (lambda (&rest args) (declare (ignore args)))
-    (add-reply-responder
-     "/n_before" (lambda (&rest args) (declare (ignore args))))
-    (add-reply-responder
-     "/n_after" (lambda (&rest args) (declare (ignore args))))))
+     "/d_removed" (lambda (&rest args) (declare (ignore args))))))
 
 (defun control-get (index &optional action)
   (let ((result nil)
@@ -631,43 +623,6 @@
 										  (t (floatfy p))))
                                                                 param))
                         server)))
-
-;; move nodes
-
-(defun move-after (node before-node)
-  (with-node (node id server)
-    (with-node (before-node b-id server2)
-      (send-message server "/n_after" id b-id))))
-
-(defun move-after (node after-node)
-  (send-message *s* "/n_after" node
-  
-  (let ((id)
-        (after-id))
-    (cl-collider::with-node (node cid server)
-      (setf id cid))
-    (cl-collider::with-node (after-node aid server)
-      (setf after-id aid)
-      (send-message server "/n_after" id after-id))))
-
-(defun move-to-head (group node)
-  (let ((id)
-        (group-id))
-    (cl-collider::with-node (node cid server)
-      (setf id cid))
-    (cl-collider::with-node (group gid server)
-      (setf group-id gid))
-    (send-message server "g_head" group-id id)))
-
-(defun move-to-tail (group node)
-  (let ((id)
-        (group-id))
-    (cl-collider::with-node (node cid server)
-      (setf id cid))
-    (cl-collider::with-node (group gid server)
-      (setf group-id gid))
-    (send-message server "g_tail" group-id id)))
-
 
 (defmethod free ((node node))
   (with-node (node id server)

--- a/server.lisp
+++ b/server.lisp
@@ -373,7 +373,15 @@
        (declare (ignore args))
        (alexandria:removef (node-watcher rt-server) id)))
     (add-reply-responder
-     "/d_removed" (lambda (&rest args) (declare (ignore args))))))
+     "/d_removed" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/g_head" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/g_tail" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/n_before" (lambda (&rest args) (declare (ignore args))))
+    (add-reply-responder
+     "/n_after" (lambda (&rest args) (declare (ignore args))))))
 
 (defun control-get (index &optional action)
   (let ((result nil)
@@ -623,6 +631,41 @@
 										  (t (floatfy p))))
                                                                 param))
                         server)))
+
+;; move nodes
+
+(defun move-after (node before-node)
+  (with-node (node id server)
+    (with-node (before-node b-id server2)
+      (send-message server "/n_after" id b-id))))
+
+(defun move-after (node after-node)  
+  (let ((id)
+        (after-id))
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (after-node aid server)
+      (setf after-id aid)
+      (send-message server "/n_after" id after-id))))
+
+(defun move-to-head (group node)
+  (let ((id)
+        (group-id))
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (group gid server)
+      (setf group-id gid))
+    (send-message server "g_head" group-id id)))
+
+(defun move-to-tail (group node)
+  (let ((id)
+        (group-id))q
+    (cl-collider::with-node (node cid server)
+      (setf id cid))
+    (cl-collider::with-node (group gid server)
+      (setf group-id gid))
+    (send-message server "g_tail" group-id id)))
+
 
 (defmethod free ((node node))
   (with-node (node id server)


### PR DESCRIPTION
This fixes #134 

Four new functions added for moving a node, and moving a node to head/tail of a group.