### PR TITLE
This fixes a problem where the server would not boot up a second time

### DIFF
--- a/server-options.lisp
+++ b/server-options.lisp
@@ -27,7 +27,8 @@
 
 (defun build-server-options (server-options)
   ;; If the hardware buffer size is 0, do not apply the -Z option
-  (when (zerop (server-options-hardware-buffer-size server-options))
+  (when (and (server-options-hardware-buffer-size server-options)
+             (zerop (server-options-hardware-buffer-size server-options)))
     (setf (server-options-hardware-buffer-size server-options) nil))
   (reduce #'append
 	  (mapcar (lambda (pair)


### PR DESCRIPTION
If the hardware buffer size is set to 0, then the server would not boot up a second time due to a null issue.

This fixes that.