### PR TITLE
Fixed buffer-fill so it handles frequencies and phases properly

### DIFF
--- a/buffer.lisp
+++ b/buffer.lisp
@@ -411,19 +411,32 @@ In the case of sine wave partials, AMPLITUDES is a list whose first value specif
 Chebyshev polynomials can be defined as cheby(n) = amplitude * cos(n * acos(x)). In this case, the first value of AMPLITUDES specifies the amplitude for n = 1, the second value specifies the amplitude for n = 2, and so on. FREQUENCIES and PHASES are ignored.
 
 When NORMALIZE is T, the peak amplitude of the wave is normalized to 1.0. If WAVETABLE is set to T, the buffer is written in a special wavetable format so that it can be read by interpolating oscillators. Setting CLEAR-FIRST to T clears the buffer before new partials are written into it. If NIL, the new partials are summed with the existing contents of the buffer."
+  (flet ((convert-ratios (xs) (when xs (mapcar (lambda (x) (if (typep x 'ratio) (float x) x))xs))))
+    (setf amplitudes (convert-ratios amplitudes))
+    (setf frequencies (convert-ratios frequencies))
+    (setf phases (convert-ratios phases)))
   (apply #'send-message
 	 (server buffer)
 	 (append (list "/b_gen" (bufnum buffer)
 		       (ecase wave
 			 (:cheby "cheby")
-			 (:sine (cond ((and frequencies phases) "sine3")
+			 (:sine (cond (phases "sine3")
 				      (frequencies "sine2")
 				      (t "sine1"))))
 		       (+ (if normalize 1 0)
 			  (if as-wavetable 2 0)
 			  (if clear-first 4 0)))
-		 (if (and (eql wave :sine) frequencies)
-		     (append frequencies amplitudes phases)
+		 (if (eql wave :sine)
+                     (cond ((and frequencies phases)
+                            (alexandria:flatten (mapcar #'list
+                                                        frequencies amplitudes phases)))
+                           (phases
+                            (alexandria:flatten (mapcar #'list
+                                                        (loop for x from 1 to (length amplitudes)
+                                                              collect x)
+                                                        amplitudes phases)))
+                           (frequencies
+                            (alexandria:flatten (mapcar #'list frequencies amplitudes))))
 		     amplitudes)))
   (sync server))
 


### PR DESCRIPTION
buffer-fill was not creating buffers when specifying frequencies and phases properly:

e.g. compare this supercollider code:
```supercollider
(
b = Buffer.alloc(s, 16384);
b.sine2(
        amps: [1, 0.4, 0.16, 0.064, 0.0256, 0.01024, 0.004096, 0.0016384],
	freqs: [1, 2, 3, 5, 8, 13, 21, 34]
);
)
x = {
	var sig;
	sig = Osc.ar(b, 200);
	sig = sig * 0.2 ! 2;
}.play;
)
```

with the following in cl-collider:
```cl
(progn
  (buffer-free *b*)
  (setf *b* (buffer-alloc 16384))
  (buffer-fill *b* :sine
               (1 0.4 0.16 0.064 0.0256 0.01024 0.004096 0.0016384),
                   :frequencies               
                   (1 2 3 5 8 13 21 34)))

(setf *x*
      (play
       (dup (* 0.2 (osc.ar *b* 200)))))
(release *x*)
```

The problem was that cl-collider was not interleaving the lists as sclang does. This PR fixes this.

In addition this PR adds two conveniences:
1. It is possible to pass in phases without the frequencies (it will just create a list of the right size that goes from 1..N)
2. It is now possible to pass in lists that contain ratios (such as 1/3). These will be converted to floats.

