### PR TITLE
Added env-circle, and added optional parameter to delay1

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -193,6 +193,7 @@
 	   #:dadsr
 	   #:adsr
 	   #:asr
+           #:env-circle
 	   #:env-at
 	   #:env-as-signal
 

--- a/ugens/Delays.lisp
+++ b/ugens/Delays.lisp
@@ -8,13 +8,13 @@
 		  (k2a.ar in)))))
     (multinew op nil input)))
 
-(defugen (Delay-1 "Delay1") (&optional (in 0.0) (mul 1.0) (add 0.0))
-  ((:ar (madd (multinew new 'pure-ugen in) mul add))
-   (:kr (madd (multinew new 'pure-ugen in) mul add))))
+(defugen (Delay-1 "Delay1") (&optional (in 0.0) (mul 1.0) (add 0.0) x1)
+  ((:ar (madd (multinew new 'pure-ugen in (if x1 x1 0.0)) mul add))
+   (:kr (madd (multinew new 'pure-ugen in (if x1 x1 in)) mul add))))
 
-(defugen (Delay-2 "Delay2") (&optional (in 0.0) (mul 1.0) (add 0.0))
-  ((:ar (madd (multinew new 'pure-ugen in) mul add))
-   (:kr (madd (multinew new 'pure-ugen in) mul add))))
+(defugen (Delay-2 "Delay2") (&optional (in 0.0) (mul 1.0) (add 0.0) x1 x2)
+  ((:ar (madd (multinew new 'pure-ugen in (if x1 x1 0.0) (if x2 x2 0.0)) mul add))
+   (:kr (madd (multinew new 'pure-ugen in (if x1 x1 in) (if x2 x2 in)) mul add))))
 
 
 (defugen (delay-n "DelayN")

--- a/ugens/EnvGen.lisp
+++ b/ugens/EnvGen.lisp
@@ -191,6 +191,27 @@
        curve
        1))
 
+(defun env-circle (levels times &optional (curve :lin) (loop-time 0.0)
+                                  (loop-curve :lin) (rate :kr))
+  "Make envelope that will cycle through its values.
+loop-curve and loop-time set the duration and curve for the loop back segment.
+Use rate :ar if you want to use this inside an EnvGen.ar."
+  (let* ((curve (loop with curve = (alexandria:ensure-list curve)
+                      with len = (length curve)
+                      for i from 0 below (length times)
+                      collect (nth (mod i len) curve)))
+         (curve (append (cons loop-curve curve) (list :lin)));; dummy value at end
+         (levels (append (cons (car levels) levels) (list 0.0))) ;; dummy value at end
+         (first0-then1 (cond ((equal loop-time 0) 0)
+                             ((eql rate :ar)
+                              (sc::mul loop-time
+                                 (latch.ar 1.0 (delay-1.ar (impulse.ar 0.0) 1 0 0.0))))
+                             (t (sc::mul loop-time
+                                   (latch.kr 1.0 (delay-1.kr (impulse.kr 0.0) 1 0 0.0))))))
+         (times (append (cons first0-then1 times) (list +inf+)))
+         (release-node (- (length levels) 2))) ;; dummy value at end
+    (env levels times curve release-node 0)))
+
 ;;; Interpolation formulas adapted from Overtone
 
 (defun step-interpolation (pos y1 y2)


### PR DESCRIPTION
Created new function env-circle, which does the same as Env.circle, but with a slightly modified API to make it more standard and slightly more flexible.

Added :x1 and x1/x2 as optional parameters so that delay1 and delay2 have exact parity with the SuperCollider interface (this was needed for env-circle - but these parameters are sometimes necessary for other purposes).