### PR TITLE
Added 1+ and 1- as synthdef equivalent functions

### DIFF
--- a/operators.lisp
+++ b/operators.lisp
@@ -304,6 +304,13 @@
 (defun ash~ (in1 in2)
   (if (plusp in2) (<< in1 in2)
       (>> in1 (- in2))))
+
+(defun 1+~ (i)
+  (+ 1 i))
+
+(defun 1-~ (i)
+  (- i 1))
+
 ;;;
 ;;;
 ;;;

--- a/synthdef.lisp
+++ b/synthdef.lisp
@@ -285,7 +285,9 @@
 				    (min sc::min~)
 				    (logand sc::logand~)
 				    (logior sc::logior~)
-				    (ash sc::ash~))
+				    (ash sc::ash~)
+                                    (1+ sc::1+~)
+                                    (1- sc::1-~))
   "Table mapping function names to their synthdef-compatible equivalents. Used by `convert-code' and `synthdef-equivalent-function' to convert lisp functions in synthdef bodies to ugen functions.")
 
 (defun synthdef-equivalent-function (function)


### PR DESCRIPTION
I use 1+ and 1- a lot when using common lisp, as it makes my code easier to read. I got frustrated that this didn't work in cl-collider so I decided to do something about it.

